### PR TITLE
[BUGFIX] Use multi-stage Docker build to assure PHP 8.0 in Docker image

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   deploy:
-    name: Composer ${{ matrix.composer-version }}
     if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
-FROM composer:2
+FROM composer:2 AS composer
 LABEL maintainer="Elias Häußler <elias@haeussler.dev>"
+
+FROM php:8.0-alpine
+COPY --from=composer /usr/bin/composer /usr/bin/composer
 
 ADD . /app
 WORKDIR /app


### PR DESCRIPTION
This PR ensures a compatible PHP version is used when building the Docker image. The PHP version is now locked to PHP 8.0.x.