### PR TITLE
[FEATURE] Enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+
+# Configuration: https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates
+updates:
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: daily
+    commit-message:
+      prefix: '[TASK]'
+    target-branch: develop
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -20,6 +20,9 @@ changelog:
     - title: 🚑 Fixed
       labels:
         - bug
+    - title: ⚙️ Dependencies
+      labels:
+        - dependencies
     - title: Other changes
       labels:
         - "*"


### PR DESCRIPTION
This PR enables Dependabot updates for GitHub Actions.