### PR TITLE
[BUGFIX] Include all tracked PHP files in PHP-CS-Fixer

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -41,10 +41,10 @@ along with this program. If not, see <https://www.gnu.org/licenses/>.
 EOM;
 
 $finder = \PhpCsFixer\Finder::create()
-    ->in([
-        __DIR__.'/src',
-        __DIR__.'/tests',
-    ])
+    ->files()
+    ->in(__DIR__)
+    ->name('*.php')
+    ->ignoreVCSignored(true)
 ;
 $config = new \PhpCsFixer\Config();
 


### PR DESCRIPTION
Prior to this PR, only PHP files in `src` and `tests` were included in PHP-CS-Fixer config. This PR now includes all tracked files.