### PR TITLE
[BUGFIX] Make downloaded PHAR artifact executable

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -67,6 +67,8 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: phar
+      - name: Make PHAR executable
+        run: chmod +x .build/cache-warmup.phar
 
       # Generate metadata
       - name: Generate image metadata
@@ -117,6 +119,8 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: phar
+      - name: Make PHAR executable
+        run: chmod +x .build/cache-warmup.phar
 
       # Create release
       - name: Create release


### PR DESCRIPTION
Since [file permissions are not maintained during artifact upload](https://github.com/actions/download-artifact#limitations), we need to make the downloaded PHAR artifact executable.