### PR TITLE
[BUGFIX] Switch to PHP 7.4 for PHAR file generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 7.4
           tools: composer:v2
 
       # Compile PHAR


### PR DESCRIPTION
This is required once https://github.com/box-project/box/pull/644 is released. `humbug/box` is currently not able to handle PHP 8.0 and PHP 8.1 in Dockerfiles.