### PR TITLE
[BUGFIX] Assure release jobs can be run on scheduled workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,7 +10,6 @@ on:
 jobs:
   phar:
     name: Compile PHAR
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
@@ -51,7 +50,6 @@ jobs:
 
   docker:
     name: Docker deploy
-    if: startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-20.04
     needs: phar
     steps:
@@ -108,7 +106,7 @@ jobs:
   # Job: Create release
   release:
     name: Create release
-    if: ${{ startsWith(github.ref, 'refs/tags/') && github.event_name != 'schedule' }}
+    if: github.event_name != 'schedule'
     runs-on: ubuntu-20.04
     needs: phar
     steps:


### PR DESCRIPTION
Since scheduled workflows always run on the main branch, we must remove all conditions assuming the workflow is run on a specific tag.