### PR TITLE
[TASK] Skip concurrent workflow runs

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -2,7 +2,8 @@ name: CGL
 on:
   push:
     branches:
-      - '**'
+      - main
+      - develop
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,8 @@ name: Tests
 on:
   push:
     branches:
-      - '**'
+      - main
+      - develop
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
With this PR, CGL and test workflows are only run in `main` and `develop` branches for the push event. This avoid concurrent workflow runs in case PRs are opened for feature branches or other branches.