### PR TITLE
[BUGFIX] Resolve deprecations and migrate to PHPUnit 9.x

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"
@@ -92,7 +91,6 @@ jobs:
       fail-fast: false
       matrix:
         php-version:
-          - "7.2"
           - "7.3"
           - "7.4"
           - "8.0"

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -43,7 +43,10 @@ EOM;
 $finder = \PhpCsFixer\Finder::create()
     ->files()
     ->in(__DIR__)
-    ->name('*.php')
+    ->name([
+        'cache-warmup',
+        '*.php',
+    ])
     ->ignoreVCSignored(true)
 ;
 $config = new \PhpCsFixer\Config();

--- a/bin/cache-warmup
+++ b/bin/cache-warmup
@@ -1,11 +1,12 @@
 #!/usr/bin/env php
 <?php
+
 declare(strict_types=1);
 
 /*
  * This file is part of the Composer package "eliashaeussler/cache-warmup".
  *
- * Copyright (C) 2020 Elias Häußler <elias@haeussler.dev>
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,16 +24,16 @@ declare(strict_types=1);
 
 // Check Composer autoloader
 $autoloadFile = null;
-foreach ([__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php'] as $file) {
+foreach ([__DIR__.'/../../../autoload.php', __DIR__.'/../vendor/autoload.php', __DIR__.'/vendor/autoload.php'] as $file) {
     if (file_exists($file)) {
         $autoloadFile = $file;
         break;
     }
 }
-if ($autoloadFile === null) {
+if (null === $autoloadFile) {
     $message = 'Unable to determine path to Composer autoload file. Please set up your project using Composer.';
     fwrite(STDERR, $message);
-    die(1);
+    exit(1);
 }
 
 // Require Composer autoloader

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
     "ergebnis/composer-normalize": "^2.8",
     "friendsofphp/php-cs-fixer": ">= 2.17 < 4.0",
     "jangregor/phpstan-prophecy": "^1.0",
+    "phpspec/prophecy-phpunit": "^2.0",
     "phpstan/phpstan": "^1.2",
     "phpstan/phpstan-phpunit": "^1.1",
     "phpunit/phpunit": ">= 8.5.23 < 10.0"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "phpspec/prophecy-phpunit": "^2.0",
     "phpstan/phpstan": "^1.2",
     "phpstan/phpstan-phpunit": "^1.1",
-    "phpunit/phpunit": ">= 8.5.23 < 10.0"
+    "phpunit/phpunit": "^9.3"
   },
   "autoload": {
     "psr-4": {

--- a/phpunit.coverage.xml
+++ b/phpunit.coverage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="false"
          convertErrorsToExceptions="true"
@@ -9,20 +9,22 @@
          executionOrder="defects"
          verbose="true"
 >
-    <testsuites>
-        <testsuite name="Unit Tests">
-            <directory suffix="Test.php">tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true" />
-        <log type="coverage-clover" target=".build/coverage/clover.xml" showUncoveredFiles="true" />
-        <log type="coverage-html" target=".build/coverage/html" />
-        <log type="junit" target=".build/coverage/junit.xml" />
-    </logging>
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+    <report>
+      <clover outputFile=".build/coverage/clover.xml"/>
+      <html outputDirectory=".build/coverage/html"/>
+      <text outputFile="php://stdout" showUncoveredFiles="true"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit Tests">
+      <directory suffix="Test.php">tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile=".build/coverage/junit.xml"/>
+  </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/6.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          convertErrorsToExceptions="true"
@@ -9,17 +9,17 @@
          executionOrder="defects"
          verbose="true"
 >
-    <testsuites>
-        <testsuite name="Unit Tests">
-            <directory suffix="Test.php">tests/Unit</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="junit" target=".build/coverage/junit.xml" />
-    </logging>
+  <coverage processUncoveredFiles="false">
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="Unit Tests">
+      <directory suffix="Test.php">tests/Unit</directory>
+    </testsuite>
+  </testsuites>
+  <logging>
+    <junit outputFile=".build/coverage/junit.xml"/>
+  </logging>
 </phpunit>

--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -117,7 +117,7 @@ final class XmlParser
             return null;
         }
 
-        $sitemapUri = reset($xml->loc);
+        $sitemapUri = $xml->loc[0];
         $sitemapUri = new Uri((string) $sitemapUri);
 
         return new Sitemap($sitemapUri);
@@ -129,7 +129,7 @@ final class XmlParser
             return null;
         }
 
-        $uri = reset($xml->loc);
+        $uri = $xml->loc[0];
 
         return new Uri((string) $uri);
     }

--- a/tests/Unit/CacheWarmerTest.php
+++ b/tests/Unit/CacheWarmerTest.php
@@ -27,6 +27,7 @@ use EliasHaeussler\CacheWarmup\CacheWarmer;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\UriInterface;
@@ -39,6 +40,7 @@ use Psr\Http\Message\UriInterface;
  */
 final class CacheWarmerTest extends TestCase
 {
+    use ProphecyTrait;
     use RequestProphecyTrait;
     use CrawlerResultProcessorTrait;
 

--- a/tests/Unit/CacheWarmerTest.php
+++ b/tests/Unit/CacheWarmerTest.php
@@ -68,7 +68,7 @@ final class CacheWarmerTest extends TestCase
         }
         $crawler = $this->subject->run();
         $processedUrls = $this->getProcessedUrlsFromCrawler($crawler);
-        static::assertTrue([] === array_diff($urls, $processedUrls));
+        self::assertTrue([] === array_diff($urls, $processedUrls));
     }
 
     /**
@@ -118,11 +118,11 @@ final class CacheWarmerTest extends TestCase
 
         // Add sitemap (first time)
         $this->subject->addSitemaps('https://www.example.org/sitemap.xml');
-        static::assertEquals($expected, $this->subject->getUrls());
+        self::assertEquals($expected, $this->subject->getUrls());
 
         // Add sitemap (second time)
         $this->subject->addSitemaps('https://www.example.com/sitemap.xml');
-        static::assertEquals($expected, $this->subject->getUrls());
+        self::assertEquals($expected, $this->subject->getUrls());
     }
 
     /**
@@ -146,8 +146,8 @@ final class CacheWarmerTest extends TestCase
             $this->prophesizeSitemapRequest($fixture, $expectedUri);
         }
         $this->subject->addSitemaps($sitemaps);
-        static::assertEquals($expectedSitemaps, $this->subject->getSitemaps());
-        static::assertEquals($expectedUrls, $this->subject->getUrls());
+        self::assertEquals($expectedSitemaps, $this->subject->getSitemaps());
+        self::assertEquals($expectedUrls, $this->subject->getUrls());
     }
 
     /**
@@ -156,7 +156,7 @@ final class CacheWarmerTest extends TestCase
     public function addUrlAddsGivenUrlToListOfUrls(): void
     {
         $url = $this->getExpectedUri('https://www.example.org/sitemap.xml');
-        static::assertSame([$url], $this->subject->addUrl($url)->getUrls());
+        self::assertSame([$url], $this->subject->addUrl($url)->getUrls());
     }
 
     /**
@@ -165,7 +165,7 @@ final class CacheWarmerTest extends TestCase
     public function addUrlDoesNotAddAlreadyAvailableUrlToListOfUrls(): void
     {
         $url = $this->getExpectedUri('https://www.example.org/sitemap.xml');
-        static::assertSame([$url], $this->subject->addUrl($url)->addUrl($url)->getUrls());
+        self::assertSame([$url], $this->subject->addUrl($url)->addUrl($url)->getUrls());
     }
 
     /**
@@ -179,7 +179,7 @@ final class CacheWarmerTest extends TestCase
         $this->subject->setLimit(1);
         $this->subject->addUrl($url1)->addUrl($url2);
 
-        static::assertSame([$url1], $this->subject->getUrls());
+        self::assertSame([$url1], $this->subject->getUrls());
     }
 
     /**
@@ -187,8 +187,8 @@ final class CacheWarmerTest extends TestCase
      */
     public function getLimitReturnsUrlLimit(): void
     {
-        static::assertSame(0, $this->subject->getLimit());
-        static::assertSame(10, $this->subject->setLimit(10)->getLimit());
+        self::assertSame(0, $this->subject->getLimit());
+        self::assertSame(10, $this->subject->setLimit(10)->getLimit());
     }
 
     /**
@@ -197,7 +197,7 @@ final class CacheWarmerTest extends TestCase
     public function setLimitDefinesUrlLimit(): void
     {
         $this->subject->setLimit(10);
-        static::assertSame(10, $this->subject->getLimit());
+        self::assertSame(10, $this->subject->getLimit());
     }
 
     /**

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -29,6 +29,7 @@ use EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\DummyVerboseCrawler;
 use EliasHaeussler\CacheWarmup\Tests\Unit\RequestProphecyTrait;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Console\Application;
@@ -44,6 +45,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 final class CacheWarmupCommandTest extends TestCase
 {
+    use ProphecyTrait;
     use RequestProphecyTrait;
 
     /**

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -101,9 +101,9 @@ final class CacheWarmupCommandTest extends TestCase
         $this->commandTester->execute([], ['verbosity' => OutputInterface::VERBOSITY_VERY_VERBOSE]);
 
         $output = $this->commandTester->getDisplay();
-        static::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
-        static::assertStringContainsString('* https://www.example.com/', $output);
-        static::assertStringContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
+        self::assertStringContainsString('* https://www.example.com/', $output);
+        self::assertStringContainsString('* https://www.example.com/foo', $output);
     }
 
     /**
@@ -126,9 +126,9 @@ final class CacheWarmupCommandTest extends TestCase
         );
 
         $output = $this->commandTester->getDisplay();
-        static::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
-        static::assertStringContainsString('* https://www.example.com/', $output);
-        static::assertStringContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
+        self::assertStringContainsString('* https://www.example.com/', $output);
+        self::assertStringContainsString('* https://www.example.com/foo', $output);
     }
 
     /**
@@ -152,9 +152,9 @@ final class CacheWarmupCommandTest extends TestCase
         );
 
         $output = $this->commandTester->getDisplay();
-        static::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
-        static::assertStringContainsString('* https://www.example.com/', $output);
-        static::assertStringNotContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
+        self::assertStringContainsString('* https://www.example.com/', $output);
+        self::assertStringNotContainsString('* https://www.example.com/foo', $output);
     }
 
     /**
@@ -179,8 +179,8 @@ final class CacheWarmupCommandTest extends TestCase
         );
 
         $output = $this->commandTester->getDisplay();
-        static::assertStringContainsString('* https://www.example.com/', $output);
-        static::assertStringContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('* https://www.example.com/', $output);
+        self::assertStringContainsString('* https://www.example.com/foo', $output);
     }
 
     /**
@@ -198,11 +198,11 @@ final class CacheWarmupCommandTest extends TestCase
         ]);
 
         $output = $this->commandTester->getDisplay();
-        static::assertStringContainsString('Parsing sitemaps... Done', $output);
-        static::assertStringContainsString('Crawling URLs... Done', $output);
-        static::assertStringNotContainsString('* https://www.example.com/sitemap.xml', $output);
-        static::assertStringNotContainsString('* https://www.example.com/', $output);
-        static::assertStringNotContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('Parsing sitemaps... Done', $output);
+        self::assertStringContainsString('Crawling URLs... Done', $output);
+        self::assertStringNotContainsString('* https://www.example.com/sitemap.xml', $output);
+        self::assertStringNotContainsString('* https://www.example.com/', $output);
+        self::assertStringNotContainsString('* https://www.example.com/foo', $output);
     }
 
     /**
@@ -265,7 +265,7 @@ final class CacheWarmupCommandTest extends TestCase
             new Uri('https://www.example.com/foo'),
         ];
 
-        static::assertEquals($expected, DummyCrawler::$crawledUrls);
+        self::assertEquals($expected, DummyCrawler::$crawledUrls);
     }
 
     /**
@@ -283,7 +283,7 @@ final class CacheWarmupCommandTest extends TestCase
             '--crawler' => DummyVerboseCrawler::class,
         ]);
 
-        static::assertSame($this->commandTester->getOutput(), DummyVerboseCrawler::$output);
+        self::assertSame($this->commandTester->getOutput(), DummyVerboseCrawler::$output);
     }
 
     /**

--- a/tests/Unit/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/Unit/Crawler/ConcurrentCrawlerTest.php
@@ -55,7 +55,7 @@ final class ConcurrentCrawlerTest extends TestCase
         $subject->crawl($urls);
 
         $processedUrls = $this->getProcessedUrlsFromCrawler($subject);
-        static::assertTrue([] === array_diff($urls, $processedUrls));
+        self::assertTrue([] === array_diff($urls, $processedUrls));
     }
 
     /**
@@ -69,8 +69,8 @@ final class ConcurrentCrawlerTest extends TestCase
         $subject = new ConcurrentCrawler();
         $subject->crawl($urls);
 
-        static::assertSame($urls, $this->getProcessedUrlsFromCrawler($subject, CrawlingState::SUCCESSFUL));
-        static::assertSame([], $subject->getFailedUrls());
+        self::assertSame($urls, $this->getProcessedUrlsFromCrawler($subject, CrawlingState::SUCCESSFUL));
+        self::assertSame([], $subject->getFailedUrls());
     }
 
     /**
@@ -84,7 +84,7 @@ final class ConcurrentCrawlerTest extends TestCase
         $subject = new ConcurrentCrawler();
         $subject->crawl($urls);
 
-        static::assertSame($urls, $this->getProcessedUrlsFromCrawler($subject, CrawlingState::FAILED));
-        static::assertSame([], $subject->getSuccessfulUrls());
+        self::assertSame($urls, $this->getProcessedUrlsFromCrawler($subject, CrawlingState::FAILED));
+        self::assertSame([], $subject->getSuccessfulUrls());
     }
 }

--- a/tests/Unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/Unit/Crawler/OutputtingCrawlerTest.php
@@ -79,11 +79,11 @@ final class OutputtingCrawlerTest extends TestCase
         $this->subject->crawl([$uri1, $uri2]);
 
         $output = $this->output->fetch();
-        static::assertStringMatchesRegularExpression(
+        self::assertStringMatchesRegularExpression(
             sprintf('#^\s*\d/\d [^\s]+\s+\d+%% -- %s \((success|failed)\)$#m', preg_quote((string) $uri1)),
             $output
         );
-        static::assertStringMatchesRegularExpression(
+        self::assertStringMatchesRegularExpression(
             sprintf('#^\s*\d/\d [^\s]+\s+\d+%% -- %s \(failed\)$#m', preg_quote((string) $uri2)),
             $output
         );
@@ -92,9 +92,9 @@ final class OutputtingCrawlerTest extends TestCase
     public static function assertStringMatchesRegularExpression(): void
     {
         if (method_exists(static::class, 'assertMatchesRegularExpression')) {
-            static::assertMatchesRegularExpression(...\func_get_args());
+            self::assertMatchesRegularExpression(...\func_get_args());
         } else {
-            static::assertRegExp(...\func_get_args());
+            self::assertRegExp(...\func_get_args());
         }
     }
 }

--- a/tests/Unit/CrawlingStateTest.php
+++ b/tests/Unit/CrawlingStateTest.php
@@ -54,12 +54,12 @@ final class CrawlingStateTest extends TestCase
         $data = ['foo' => 'baz'];
         $subject = CrawlingState::createSuccessful($uri, $data);
 
-        static::assertSame($uri, $subject->getUri());
-        static::assertSame($data, $subject->getData());
-        static::assertTrue($subject->isSuccessful());
-        static::assertTrue($subject->is(CrawlingState::SUCCESSFUL));
-        static::assertFalse($subject->isFailed());
-        static::assertFalse($subject->is(CrawlingState::FAILED));
+        self::assertSame($uri, $subject->getUri());
+        self::assertSame($data, $subject->getData());
+        self::assertTrue($subject->isSuccessful());
+        self::assertTrue($subject->is(CrawlingState::SUCCESSFUL));
+        self::assertFalse($subject->isFailed());
+        self::assertFalse($subject->is(CrawlingState::FAILED));
     }
 
     /**
@@ -71,11 +71,11 @@ final class CrawlingStateTest extends TestCase
         $data = ['foo' => 'baz'];
         $subject = CrawlingState::createFailed($uri, $data);
 
-        static::assertSame($uri, $subject->getUri());
-        static::assertSame($data, $subject->getData());
-        static::assertTrue($subject->isFailed());
-        static::assertTrue($subject->is(CrawlingState::FAILED));
-        static::assertFalse($subject->isSuccessful());
-        static::assertFalse($subject->is(CrawlingState::SUCCESSFUL));
+        self::assertSame($uri, $subject->getUri());
+        self::assertSame($data, $subject->getData());
+        self::assertTrue($subject->isFailed());
+        self::assertTrue($subject->is(CrawlingState::FAILED));
+        self::assertFalse($subject->isSuccessful());
+        self::assertFalse($subject->is(CrawlingState::SUCCESSFUL));
     }
 }

--- a/tests/Unit/SitemapTest.php
+++ b/tests/Unit/SitemapTest.php
@@ -42,6 +42,6 @@ final class SitemapTest extends TestCase
     {
         $uri = new Uri('https://foo.baz');
         $subject = new Sitemap($uri);
-        static::assertSame($uri, $subject->getUri());
+        self::assertSame($uri, $subject->getUri());
     }
 }

--- a/tests/Unit/Xml/XmlParserTest.php
+++ b/tests/Unit/Xml/XmlParserTest.php
@@ -28,6 +28,7 @@ use EliasHaeussler\CacheWarmup\Tests\Unit\RequestProphecyTrait;
 use EliasHaeussler\CacheWarmup\Xml\XmlParser;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 
@@ -39,6 +40,7 @@ use Psr\Http\Client\ClientInterface;
  */
 final class XmlParserTest extends TestCase
 {
+    use ProphecyTrait;
     use RequestProphecyTrait;
 
     /**

--- a/tests/Unit/Xml/XmlParserTest.php
+++ b/tests/Unit/Xml/XmlParserTest.php
@@ -68,8 +68,8 @@ final class XmlParserTest extends TestCase
         $expected = [
             new Sitemap(new Uri('https://www.example.org/sitemap_en.xml')),
         ];
-        static::assertEquals($expected, $this->subject->getParsedSitemaps());
-        static::assertSame([], $this->subject->getParsedUrls());
+        self::assertEquals($expected, $this->subject->getParsedSitemaps());
+        self::assertSame([], $this->subject->getParsedUrls());
     }
 
     /**
@@ -87,8 +87,8 @@ final class XmlParserTest extends TestCase
             new Uri('https://www.example.org/foo'),
             new Uri('https://www.example.org/baz'),
         ];
-        static::assertEquals($expected, $this->subject->getParsedUrls());
-        static::assertSame([], $this->subject->getParsedSitemaps());
+        self::assertEquals($expected, $this->subject->getParsedUrls());
+        self::assertSame([], $this->subject->getParsedSitemaps());
     }
 
     /**
@@ -104,8 +104,8 @@ final class XmlParserTest extends TestCase
         $expected = [
             new Sitemap(new Uri('https://www.example.org/sitemap_alt_2.xml')),
         ];
-        static::assertEquals($expected, $this->subject->getParsedSitemaps());
-        static::assertSame([], $this->subject->getParsedUrls());
+        self::assertEquals($expected, $this->subject->getParsedSitemaps());
+        self::assertSame([], $this->subject->getParsedUrls());
     }
 
     /**
@@ -122,8 +122,8 @@ final class XmlParserTest extends TestCase
             new Uri('https://www.example.org/foo'),
             new Uri('https://www.example.org/baz'),
         ];
-        static::assertEquals($expected, $this->subject->getParsedUrls());
-        static::assertSame([], $this->subject->getParsedSitemaps());
+        self::assertEquals($expected, $this->subject->getParsedUrls());
+        self::assertSame([], $this->subject->getParsedSitemaps());
     }
 
     /**
@@ -131,7 +131,7 @@ final class XmlParserTest extends TestCase
      */
     public function getParsedSitemapsReturnsEmptyArrayIfSitemapHasNotBeenCrawledYet(): void
     {
-        static::assertSame([], $this->subject->getParsedSitemaps());
+        self::assertSame([], $this->subject->getParsedSitemaps());
     }
 
     /**
@@ -139,7 +139,7 @@ final class XmlParserTest extends TestCase
      */
     public function getParsedSitemapsUrlsEmptyArrayIfSitemapHasNotBeenCrawledYet(): void
     {
-        static::assertSame([], $this->subject->getParsedUrls());
+        self::assertSame([], $this->subject->getParsedUrls());
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
This PR migrates PHPUnit to 9.x and drops tests for PHP 7.3. Additionally, the trait from `phpspec/prophecy-phpunit` is now used for prophecies in tests. On top of that, some deprecations are resolved.