### PR TITLE
[FEATURE] Build multi-platform Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,6 +104,7 @@ jobs:
         with:
           context: .
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
 
   # Job: Create release


### PR DESCRIPTION
This PR changes the target platforms for generated Docker images. The following platforms are now supported:

- [x] `linux/amd64`
- [x] `linux/arm64`