### PR TITLE
[!!!][BUGFIX] Drop support for `symfony/console` < 4.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "guzzlehttp/psr7": ">= 1.8 < 3.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0",
-    "symfony/console": ">= 3.4 < 6.0"
+    "symfony/console": ">= 4.2.2 < 6.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2.8",


### PR DESCRIPTION
With this PR, support for very old versions of `symfony/console` is dropped. The minimum required version is now 4.2.2. Previous versions cause problems when installing the package with lowest requirements on PHP 7.4 and 7.3.