### PR TITLE
[BUGFIX] Analyze `bin/cache-warmup` file with PHPStan

### DIFF
--- a/bin/cache-warmup
+++ b/bin/cache-warmup
@@ -44,5 +44,5 @@ unset($autoloadFile, $file);
 $command = new \EliasHaeussler\CacheWarmup\Command\CacheWarmupCommand();
 $application = new \Symfony\Component\Console\Application('Cache Warmup');
 $application->add($command);
-$application->setDefaultCommand($command->getName(), true);
+$application->setDefaultCommand('cache-warmup', true);
 $application->run();

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,7 @@ includes:
 parameters:
     level: max
     paths:
+        - bin/cache-warmup
         - src
         - tests
     treatPhpDocTypesAsCertain: false


### PR DESCRIPTION
With this PR, the `bin/cache-warmup` entrypoint file is now analyzed with PHPStan as well.