### PR TITLE
[TASK] Enable PHP-CS-Fixer rule `global_namespace_import`

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -55,13 +55,13 @@ return $config
     ->setRules([
         '@PSR2' => true,
         '@Symfony' => true,
+        'global_namespace_import' => ['import_classes' => true, 'import_functions' => true],
         'header_comment' => [
             'header' => sprintf($header, date('Y')),
             'comment_type' => 'comment',
             'location' => 'after_declare_strict',
             'separate' => 'both',
         ],
-        'native_function_invocation' => true,
     ])
     ->setFinder($finder)
     ->setRiskyAllowed(true)

--- a/src/CacheWarmer.php
+++ b/src/CacheWarmer.php
@@ -23,11 +23,24 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup;
 
+use function count;
+
 use EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler;
 use EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface;
 use EliasHaeussler\CacheWarmup\Xml\XmlParser;
+
+use function gettype;
+
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\Uri;
+
+use function in_array;
+
+use InvalidArgumentException;
+
+use function is_array;
+use function is_string;
+
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\UriInterface;
 
@@ -93,14 +106,14 @@ final class CacheWarmer
         }
 
         // Force array of sitemaps to be parsed
-        if (!\is_array($sitemaps)) {
+        if (!is_array($sitemaps)) {
             $sitemaps = [$sitemaps];
         }
 
         // Validate and parse given sitemaps
         foreach ($sitemaps as $sitemap) {
             // Parse sitemap URL to valid sitemap object
-            if (\is_string($sitemap)) {
+            if (is_string($sitemap)) {
                 $this->validateSitemapUrl($sitemap);
                 $sitemap = new Sitemap(new Uri($sitemap));
             }
@@ -116,7 +129,7 @@ final class CacheWarmer
                     $this->addUrl($parsedUrl);
                 }
             } else {
-                throw new \InvalidArgumentException(sprintf('Sitemaps must be of type string or %s, %s given.', Sitemap::class, \gettype($sitemap)), 1604055096);
+                throw new InvalidArgumentException(sprintf('Sitemaps must be of type string or %s, %s given.', Sitemap::class, gettype($sitemap)), 1604055096);
             }
         }
 
@@ -125,7 +138,7 @@ final class CacheWarmer
 
     private function addSitemap(Sitemap $sitemap): self
     {
-        if (!\in_array($sitemap, $this->sitemaps, true)) {
+        if (!in_array($sitemap, $this->sitemaps, true)) {
             $this->sitemaps[] = $sitemap;
         }
 
@@ -134,7 +147,7 @@ final class CacheWarmer
 
     public function addUrl(UriInterface $url): self
     {
-        if (!$this->exceededLimit() && !\in_array($url, $this->urls, true)) {
+        if (!$this->exceededLimit() && !in_array($url, $this->urls, true)) {
             $this->urls[] = $url;
         }
 
@@ -143,7 +156,7 @@ final class CacheWarmer
 
     private function exceededLimit(): bool
     {
-        return $this->limit > 0 && \count($this->urls) >= $this->limit;
+        return $this->limit > 0 && count($this->urls) >= $this->limit;
     }
 
     /**
@@ -177,10 +190,10 @@ final class CacheWarmer
     private function validateSitemapUrl(string $url): void
     {
         if ('' === trim($url)) {
-            throw new \InvalidArgumentException('Sitemap URL must not be empty.', 1604055264);
+            throw new InvalidArgumentException('Sitemap URL must not be empty.', 1604055264);
         }
         if (false === filter_var($url, FILTER_VALIDATE_URL)) {
-            throw new \InvalidArgumentException('Sitemap must be a valid URL.', 1604055334);
+            throw new InvalidArgumentException('Sitemap must be a valid URL.', 1604055334);
         }
     }
 }

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Command;
 
+use function assert;
+use function count;
+
 use EliasHaeussler\CacheWarmup\CacheWarmer;
 use EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler;
 use EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface;
@@ -31,6 +34,10 @@ use EliasHaeussler\CacheWarmup\Crawler\VerboseCrawlerInterface;
 use EliasHaeussler\CacheWarmup\CrawlingState;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use GuzzleHttp\Psr7\Uri;
+
+use function in_array;
+use function is_string;
+
 use Psr\Http\Client\ClientInterface;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Exception\RuntimeException;
@@ -161,11 +168,11 @@ final class CacheWarmupCommand extends Command
         do {
             $question = new Question('Please enter the URL of a XML sitemap: ');
             $sitemap = $helper->ask($input, $output, $question);
-            if (\is_string($sitemap)) {
+            if (is_string($sitemap)) {
                 $sitemaps[] = $sitemap;
                 $output->writeln(sprintf('<info>Sitemap added: %s</info>', $sitemap));
             }
-        } while (\is_string($sitemap));
+        } while (is_string($sitemap));
 
         // Throw exception if no sitemaps were added
         if ([] === $sitemaps && [] === $input->getOption('urls')) {
@@ -192,7 +199,7 @@ final class CacheWarmupCommand extends Command
         $output->write('Parsing sitemaps... ');
         $cacheWarmer = new CacheWarmer($sitemaps, $limit, $this->client);
         foreach ($urls as $url) {
-            \assert(\is_string($url));
+            assert(is_string($url));
             $cacheWarmer->addUrl(new Uri($url));
         }
         $output->writeln('<info>Done</info>');
@@ -215,7 +222,7 @@ final class CacheWarmupCommand extends Command
         $isVerboseCrawler = $crawler instanceof VerboseCrawlerInterface;
 
         // Start crawling
-        $urlCount = \count($cacheWarmer->getUrls());
+        $urlCount = count($cacheWarmer->getUrls());
         $output->write(sprintf('Crawling URL%s... ', 1 === $urlCount ? '' : 's'), $isVerboseCrawler);
         $cacheWarmer->run($crawler);
         if (!$isVerboseCrawler) {
@@ -238,7 +245,7 @@ final class CacheWarmupCommand extends Command
 
         // Print crawler results
         if ([] !== $successfulUrls) {
-            $countSuccessfulUrls = \count($successfulUrls);
+            $countSuccessfulUrls = count($successfulUrls);
             $io->success(
                 sprintf(
                     'Successfully warmed up caches for %d URL%s.',
@@ -248,7 +255,7 @@ final class CacheWarmupCommand extends Command
             );
         }
         if ([] !== $failedUrls) {
-            $countFailedUrls = \count($failedUrls);
+            $countFailedUrls = count($failedUrls);
             $io->error(
                 sprintf(
                     'Failed to warm up caches for %d URL%s.',
@@ -267,12 +274,12 @@ final class CacheWarmupCommand extends Command
     {
         $crawler = $input->getOption('crawler');
 
-        if (\is_string($crawler)) {
+        if (is_string($crawler)) {
             // Use crawler specified by --crawler option
             if (!class_exists($crawler)) {
                 throw new RuntimeException('The specified crawler class does not exist.', 1604261816);
             }
-            if (!\in_array(CrawlerInterface::class, class_implements($crawler) ?: [])) {
+            if (!in_array(CrawlerInterface::class, class_implements($crawler) ?: [])) {
                 throw new RuntimeException('The specified crawler is not valid.', 1604261885);
             }
             /** @var CrawlerInterface $crawler */

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -28,8 +28,10 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7\Request;
+use Iterator;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\UriInterface;
+use Throwable;
 
 /**
  * ConcurrentCrawler.
@@ -90,7 +92,7 @@ class ConcurrentCrawler implements CrawlerInterface
         $this->successfulUrls[] = CrawlingState::createSuccessful($this->urls[$index], $data);
     }
 
-    public function onFailure(\Throwable $exception, int $index): void
+    public function onFailure(Throwable $exception, int $index): void
     {
         $data = [
             'exception' => $exception,
@@ -99,9 +101,9 @@ class ConcurrentCrawler implements CrawlerInterface
     }
 
     /**
-     * @return \Iterator<Request>
+     * @return Iterator<Request>
      */
-    protected function getRequests(): \Iterator
+    protected function getRequests(): Iterator
     {
         foreach ($this->urls as $url) {
             yield new Request('HEAD', $url);

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -23,10 +23,13 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
+use function count;
+
 use EliasHaeussler\CacheWarmup\Exception\MissingArgumentException;
 use Psr\Http\Message\ResponseInterface;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 /**
  * OutputtingCrawler.
@@ -62,7 +65,7 @@ class OutputtingCrawler extends ConcurrentCrawler implements VerboseCrawlerInter
     public function crawl(array $urls): void
     {
         $this->assureOutputIsAvailable();
-        $this->startProgressBar(\count($urls));
+        $this->startProgressBar(count($urls));
         parent::crawl($urls);
         $this->progress->finish();
         $this->output->writeln('');
@@ -77,7 +80,7 @@ class OutputtingCrawler extends ConcurrentCrawler implements VerboseCrawlerInter
         parent::onSuccess($response, $index);
     }
 
-    public function onFailure(\Throwable $exception, int $index): void
+    public function onFailure(Throwable $exception, int $index): void
     {
         $this->progress->setMessage((string) $this->urls[$index], 'url');
         $this->progress->setMessage('(<error>failed</error>)', 'state');

--- a/src/CrawlingState.php
+++ b/src/CrawlingState.php
@@ -23,6 +23,9 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup;
 
+use function in_array;
+
+use InvalidArgumentException;
 use Psr\Http\Message\UriInterface;
 
 /**
@@ -109,8 +112,8 @@ final class CrawlingState
     private function validateState(): void
     {
         $supportedStates = [self::SUCCESSFUL, self::FAILED];
-        if (!\in_array($this->state, $supportedStates, true)) {
-            throw new \InvalidArgumentException(sprintf('The given crawling state is not supported, use one of "%s" instead.', implode('", "', $supportedStates)), 1604334815);
+        if (!in_array($this->state, $supportedStates, true)) {
+            throw new InvalidArgumentException(sprintf('The given crawling state is not supported, use one of "%s" instead.', implode('", "', $supportedStates)), 1604334815);
         }
     }
 }

--- a/src/Exception/MissingArgumentException.php
+++ b/src/Exception/MissingArgumentException.php
@@ -23,13 +23,15 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Exception;
 
+use Exception;
+
 /**
  * MissingArgumentException.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class MissingArgumentException extends \Exception
+final class MissingArgumentException extends Exception
 {
     public static function create(string $argumentName): self
     {

--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -29,6 +29,7 @@ use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Uri;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\UriInterface;
+use SimpleXMLElement;
 
 /**
  * XmlParser.
@@ -72,7 +73,7 @@ final class XmlParser
         // Fetch XML source
         $request = new Request('GET', $this->sitemap->getUri());
         $response = $this->client->sendRequest($request);
-        $xml = new \SimpleXMLElement($response->getBody()->getContents(), LIBXML_NOBLANKS);
+        $xml = new SimpleXMLElement($response->getBody()->getContents(), LIBXML_NOBLANKS);
 
         // Parse XML
         switch ($xml->getName()) {
@@ -111,7 +112,7 @@ final class XmlParser
         return $this->parsedUrls;
     }
 
-    private function parseSitemap(\SimpleXMLElement $xml): ?Sitemap
+    private function parseSitemap(SimpleXMLElement $xml): ?Sitemap
     {
         if (!isset($xml->loc)) {
             return null;
@@ -123,7 +124,7 @@ final class XmlParser
         return new Sitemap($sitemapUri);
     }
 
-    private function parseUrl(\SimpleXMLElement $xml): ?UriInterface
+    private function parseUrl(SimpleXMLElement $xml): ?UriInterface
     {
         if (!isset($xml->loc)) {
             return null;

--- a/tests/Unit/CacheWarmerTest.php
+++ b/tests/Unit/CacheWarmerTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit;
 use EliasHaeussler\CacheWarmup\CacheWarmer;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use GuzzleHttp\Psr7\Uri;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -76,7 +77,7 @@ final class CacheWarmerTest extends TestCase
      */
     public function addSitemapsThrowsExceptionIfGivenSitemapIsEmpty(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1604055264);
         $this->subject->addSitemaps('');
     }
@@ -86,7 +87,7 @@ final class CacheWarmerTest extends TestCase
      */
     public function addSitemapsThrowsExceptionIfGivenSitemapIsNotValid(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1604055334);
         $this->subject->addSitemaps(['foo']);
     }
@@ -96,7 +97,7 @@ final class CacheWarmerTest extends TestCase
      */
     public function addSitemapsThrowsExceptionIfInvalidSitemapsIsGiven(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1604055096);
 
         /* @phpstan-ignore-next-line */

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -27,6 +27,8 @@ use EliasHaeussler\CacheWarmup\Command\CacheWarmupCommand;
 use EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\DummyCrawler;
 use EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\DummyVerboseCrawler;
 use EliasHaeussler\CacheWarmup\Tests\Unit\RequestProphecyTrait;
+use Exception;
+use Generator;
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Prophecy\PhpUnit\ProphecyTrait;
@@ -241,7 +243,7 @@ final class CacheWarmupCommandTest extends TestCase
             'sitemaps' => [
                 'https://www.example.com/sitemap.xml',
             ],
-            '--crawler' => \Exception::class,
+            '--crawler' => Exception::class,
         ]);
     }
 
@@ -308,7 +310,7 @@ final class CacheWarmupCommandTest extends TestCase
     /**
      * @return \Generator<string, array{bool, int}>
      */
-    public function executeFailsIfSitemapCannotBeCrawledDataProvider(): \Generator
+    public function executeFailsIfSitemapCannotBeCrawledDataProvider(): Generator
     {
         yield 'with --allow-failures' => [true, 0];
         yield 'without --allow-failures' => [false, 1];

--- a/tests/Unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/Unit/Crawler/OutputtingCrawlerTest.php
@@ -25,6 +25,9 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler;
 
 use EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler;
 use EliasHaeussler\CacheWarmup\Exception\MissingArgumentException;
+
+use function func_get_args;
+
 use GuzzleHttp\Psr7\Uri;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Output\BufferedOutput;
@@ -92,9 +95,9 @@ final class OutputtingCrawlerTest extends TestCase
     public static function assertStringMatchesRegularExpression(): void
     {
         if (method_exists(static::class, 'assertMatchesRegularExpression')) {
-            self::assertMatchesRegularExpression(...\func_get_args());
+            self::assertMatchesRegularExpression(...func_get_args());
         } else {
-            self::assertRegExp(...\func_get_args());
+            self::assertRegExp(...func_get_args());
         }
     }
 }

--- a/tests/Unit/CrawlingStateTest.php
+++ b/tests/Unit/CrawlingStateTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit;
 
 use EliasHaeussler\CacheWarmup\CrawlingState;
 use GuzzleHttp\Psr7\Uri;
+use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -40,7 +41,7 @@ final class CrawlingStateTest extends TestCase
      */
     public function constructorThrowsExceptionIfInvalidCrawlingStateIsGiven(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionCode(1604334815);
         new CrawlingState(new Uri(''), -1);
     }

--- a/tests/Unit/RequestProphecyTrait.php
+++ b/tests/Unit/RequestProphecyTrait.php
@@ -26,6 +26,9 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\Psr7\Stream;
+
+use function is_resource;
+
 use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -94,7 +97,7 @@ trait RequestProphecyTrait
 
     protected function closeStream(): void
     {
-        if (\is_resource($this->stream)) {
+        if (is_resource($this->stream)) {
             fclose($this->stream);
         }
     }


### PR DESCRIPTION
This PR

- [x] enables the PHP-CS-Fixer rule `global_namespace_import`
- [x] disables the rule `native_function_invocation`