### PR TITLE
[FEATURE] Introduce configurable crawlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,14 @@ Please have a look at [`Usage with Docker`](#usage-with-docker).
 **General usage**
 
 ```bash
-./vendor/bin/cache-warmup [--urls...] [--limit] [--progress] [--crawler] [--allow-failures] [<sitemaps>...]
+./vendor/bin/cache-warmup \
+  [--urls...] \
+  [--limit] \
+  [--progress] \
+  [--crawler] \
+  [--crawler-options] \
+  [--allow-failures] \
+  [<sitemaps>...]
 ```
 
 **Extended usage**
@@ -83,6 +90,9 @@ Please have a look at [`Usage with Docker`](#usage-with-docker).
 
 # Use custom crawler (must implement EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface)
 ./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --crawler "Vendor\Crawler\MyCrawler"
+
+# Provide crawler options (only used for configurable crawlers)
+./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --crawler-options '{"concurrency": 3}'
 
 # Exit gracefully even if crawling of URLs failed
 ./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --allow-failures
@@ -118,6 +128,7 @@ $cacheWarmer->setLimit(50);
 
 // Use custom crawler (must implement EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface)
 $crawler = new \Vendor\Crawler\MyCrawler();
+$crawler->setOptions(['concurrency' => 3]);
 $cacheWarmer->run($crawler);
 
 // Define URLs to be crawled

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
 	"require": {
 		"php": ">= 7.1 < 8.2",
 		"ext-filter": "*",
+		"ext-json": "*",
 		"ext-libxml": "*",
 		"ext-simplexml": "*",
 		"guzzlehttp/guzzle": "^7.0",

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -329,7 +329,7 @@ final class CacheWarmupCommand extends Command
                 $this->io->listing($this->decorateCrawlerOptions($crawlerOptions));
             }
         } elseif (null !== $crawlerOptions) {
-            $this->io->warning('You\'ve passed crawler options to a non-configurable crawler.');
+            $this->io->warning('You passed crawler options for a non-configurable crawler.');
         }
 
         return $crawler;

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Command;
 
 use EliasHaeussler\CacheWarmup\CacheWarmer;
 use EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler;
+use EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface;
 use EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface;
 use EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler;
 use EliasHaeussler\CacheWarmup\Crawler\VerboseCrawlerInterface;
@@ -45,7 +46,9 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 use function assert;
 use function count;
 use function in_array;
+use function is_array;
 use function is_string;
+use function json_decode;
 
 /**
  * CacheWarmupCommand.
@@ -64,6 +67,11 @@ final class CacheWarmupCommand extends Command
      * @var ClientInterface|null
      */
     protected $client;
+
+    /**
+     * @var SymfonyStyle
+     */
+    private $io;
 
     protected function configure(): void
     {
@@ -105,6 +113,13 @@ final class CacheWarmupCommand extends Command
             'This can best be achieved by registering the class with Composer autoloader.',
             'Also make sure the crawler implements the <comment>'.CrawlerInterface::class.'</comment> interface.',
             '',
+            '<info>Crawler options</info>',
+            '<info>===============</info>',
+            'For crawlers implementing the <comment>'.ConfigurableCrawlerInterface::class.'</comment> interface,',
+            'it is possible to pass a JSON-encoded array of crawler options by using the <comment>--crawler-options</comment> option:',
+            '',
+            '   <comment>bin/cache-warmup --crawler-options \'{"concurrency": 3}\'</comment>',
+            '',
             '<info>Allow failures</info>',
             '<info>==============</info>',
             'If an URL fails to be crawled, this command exits with a non-zero exit code.',
@@ -145,11 +160,22 @@ final class CacheWarmupCommand extends Command
             'FQCN of the crawler to be used for cache warming'
         );
         $this->addOption(
+            'crawler-options',
+            null,
+            InputOption::VALUE_OPTIONAL,
+            'Additional config for configurable crawlers'
+        );
+        $this->addOption(
             'allow-failures',
             null,
             InputOption::VALUE_NONE,
             'Allow failures during URL crawling and exit with zero'
         );
+    }
+
+    protected function initialize(InputInterface $input, OutputInterface $output): void
+    {
+        $this->io = new SymfonyStyle($input, $output);
     }
 
     protected function interact(InputInterface $input, OutputInterface $output): void
@@ -186,12 +212,15 @@ final class CacheWarmupCommand extends Command
         $urls = $input->getOption('urls');
         $limit = (int) $input->getOption('limit');
         $allowFailures = (bool) $input->getOption('allow-failures');
-        $io = new SymfonyStyle($input, $output);
 
         // Throw exception if neither sitemaps nor URLs are defined
         if ([] === $sitemaps && [] === $urls) {
             throw new RuntimeException('Neither sitemaps nor URLs are defined.', 1604261236);
         }
+
+        // Initialize crawler
+        $crawler = $this->initializeCrawler($input, $output);
+        $isVerboseCrawler = $crawler instanceof VerboseCrawlerInterface;
 
         // Initialize cache warmer
         $output->write('Parsing sitemaps... ');
@@ -205,19 +234,15 @@ final class CacheWarmupCommand extends Command
         // Print parsed sitemaps
         if ($output->isVeryVerbose()) {
             $decoratedSitemaps = array_map([$this, 'decorateSitemap'], $cacheWarmer->getSitemaps());
-            $io->section('The following sitemaps were processed:');
-            $io->listing($decoratedSitemaps);
+            $this->io->section('The following sitemaps were processed:');
+            $this->io->listing($decoratedSitemaps);
         }
 
         // Print parsed URLs
         if ($output->isVeryVerbose()) {
-            $io->section('The following URLs will be crawled:');
-            $io->listing($cacheWarmer->getUrls());
+            $this->io->section('The following URLs will be crawled:');
+            $this->io->listing($cacheWarmer->getUrls());
         }
-
-        // Initialize crawler
-        $crawler = $this->initializeCrawler($input, $output);
-        $isVerboseCrawler = $crawler instanceof VerboseCrawlerInterface;
 
         // Start crawling
         $urlCount = count($cacheWarmer->getUrls());
@@ -232,19 +257,19 @@ final class CacheWarmupCommand extends Command
         $failedUrls = $crawler->getFailedUrls();
         if ($output->isVerbose()) {
             if ([] !== $successfulUrls) {
-                $io->section('The following URLs were successfully crawled:');
-                $io->listing($this->decorateCrawledUrls($successfulUrls));
+                $this->io->section('The following URLs were successfully crawled:');
+                $this->io->listing($this->decorateCrawledUrls($successfulUrls));
             }
             if ([] !== $failedUrls) {
-                $io->section('The following URLs failed during crawling:');
-                $io->listing($this->decorateCrawledUrls($failedUrls));
+                $this->io->section('The following URLs failed during crawling:');
+                $this->io->listing($this->decorateCrawledUrls($failedUrls));
             }
         }
 
         // Print crawler results
         if ([] !== $successfulUrls) {
             $countSuccessfulUrls = count($successfulUrls);
-            $io->success(
+            $this->io->success(
                 sprintf(
                     'Successfully warmed up caches for %d URL%s.',
                     $countSuccessfulUrls,
@@ -254,7 +279,7 @@ final class CacheWarmupCommand extends Command
         }
         if ([] !== $failedUrls) {
             $countFailedUrls = count($failedUrls);
-            $io->error(
+            $this->io->error(
                 sprintf(
                     'Failed to warm up caches for %d URL%s.',
                     $countFailedUrls,
@@ -271,6 +296,7 @@ final class CacheWarmupCommand extends Command
     protected function initializeCrawler(InputInterface $input, OutputInterface $output): CrawlerInterface
     {
         $crawler = $input->getOption('crawler');
+        $crawlerOptions = $input->getOption('crawler-options');
 
         if (is_string($crawler)) {
             // Use crawler specified by --crawler option
@@ -287,14 +313,68 @@ final class CacheWarmupCommand extends Command
             $crawler = new OutputtingCrawler();
         } else {
             // Use default crawler
-            return new ConcurrentCrawler();
+            $crawler = new ConcurrentCrawler();
         }
 
         if ($crawler instanceof VerboseCrawlerInterface) {
             $crawler->setOutput($output);
         }
 
+        if ($crawler instanceof ConfigurableCrawlerInterface) {
+            $crawlerOptions = $this->parseCrawlerOptions($crawlerOptions);
+            $crawler->setOptions($crawlerOptions);
+
+            if ($output->isVerbose() && [] !== $crawlerOptions) {
+                $this->io->section('Using custom crawler options:');
+                $this->io->listing($this->decorateCrawlerOptions($crawlerOptions));
+            }
+        } elseif (null !== $crawlerOptions) {
+            $this->io->warning('You\'ve passed crawler options to a non-configurable crawler.');
+        }
+
         return $crawler;
+    }
+
+    /**
+     * @param mixed $crawlerOptions
+     *
+     * @return array<string, mixed>
+     */
+    protected function parseCrawlerOptions($crawlerOptions): array
+    {
+        if (null === $crawlerOptions) {
+            return [];
+        }
+
+        if (is_array($crawlerOptions)) {
+            return $crawlerOptions;
+        }
+
+        if (is_string($crawlerOptions)) {
+            $crawlerOptions = json_decode($crawlerOptions, true);
+        }
+
+        if (!is_array($crawlerOptions)) {
+            throw new RuntimeException('The given crawler options are invalid. Please pass crawler options as JSON-encoded array.', 1659120649);
+        }
+
+        return $crawlerOptions;
+    }
+
+    /**
+     * @param array<string, mixed> $crawlerOptions
+     *
+     * @return list<string>
+     */
+    private function decorateCrawlerOptions(array $crawlerOptions): array
+    {
+        $decoratedCrawlerOptions = [];
+
+        foreach ($crawlerOptions as $name => $value) {
+            $decoratedCrawlerOptions[] = '<info>'.$name.'</info>: '.$value;
+        }
+
+        return $decoratedCrawlerOptions;
     }
 
     protected function decorateSitemap(Sitemap $sitemap): string

--- a/src/Crawler/AbstractConfigurableCrawler.php
+++ b/src/Crawler/AbstractConfigurableCrawler.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler;
+
+use EliasHaeussler\CacheWarmup\Exception\InvalidCrawlerOptionException;
+
+use function array_diff_key;
+
+/**
+ * AbstractConfigurableCrawler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @template TOptions of array
+ */
+abstract class AbstractConfigurableCrawler implements ConfigurableCrawlerInterface
+{
+    /**
+     * @var TOptions
+     */
+    protected static $defaultOptions = [];
+
+    /**
+     * @var TOptions
+     */
+    protected $options = [];
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function __construct(array $options = [])
+    {
+        $this->setOptions($options);
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void
+    {
+        $invalidOptions = array_diff_key($options, static::$defaultOptions);
+
+        if ([] !== $invalidOptions) {
+            throw InvalidCrawlerOptionException::createForAll($this, array_keys($invalidOptions));
+        }
+
+        $this->options = array_merge(
+            static::$defaultOptions,
+            array_intersect_key($options, static::$defaultOptions)
+        );
+    }
+}

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -38,9 +38,16 @@ use Throwable;
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
+ *
+ * @extends AbstractConfigurableCrawler<array{concurrency: int, request_method: string}>
  */
-class ConcurrentCrawler implements CrawlerInterface
+class ConcurrentCrawler extends AbstractConfigurableCrawler
 {
+    protected static $defaultOptions = [
+        'concurrency' => 5,
+        'request_method' => 'HEAD',
+    ];
+
     /**
      * @var ClientInterface
      */
@@ -61,8 +68,9 @@ class ConcurrentCrawler implements CrawlerInterface
      */
     protected $failedUrls = [];
 
-    public function __construct()
+    public function __construct(array $options = [])
     {
+        parent::__construct($options);
         $this->client = $this->initializeClient();
     }
 
@@ -74,7 +82,7 @@ class ConcurrentCrawler implements CrawlerInterface
 
         // Create request pool
         $pool = new Pool($this->client, $this->getRequests(), [
-            'concurrency' => 5,
+            'concurrency' => $this->options['concurrency'],
             'fulfilled' => [$this, 'onSuccess'],
             'rejected' => [$this, 'onFailure'],
         ]);
@@ -106,7 +114,7 @@ class ConcurrentCrawler implements CrawlerInterface
     protected function getRequests(): Iterator
     {
         foreach ($this->urls as $url) {
-            yield new Request('HEAD', $url);
+            yield new Request($this->options['request_method'], $url);
         }
     }
 

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -39,13 +39,18 @@ use Throwable;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  *
- * @extends AbstractConfigurableCrawler<array{concurrency: int, request_method: string}>
+ * @extends AbstractConfigurableCrawler<array{
+ *     concurrency: int,
+ *     request_method: string,
+ *     request_headers: array<string, string>
+ * }>
  */
 class ConcurrentCrawler extends AbstractConfigurableCrawler
 {
     protected static $defaultOptions = [
         'concurrency' => 5,
         'request_method' => 'HEAD',
+        'request_headers' => [],
     ];
 
     /**
@@ -114,7 +119,7 @@ class ConcurrentCrawler extends AbstractConfigurableCrawler
     protected function getRequests(): Iterator
     {
         foreach ($this->urls as $url) {
-            yield new Request($this->options['request_method'], $url);
+            yield new Request($this->options['request_method'], $url, $this->options['request_headers']);
         }
     }
 

--- a/src/Crawler/ConfigurableCrawlerInterface.php
+++ b/src/Crawler/ConfigurableCrawlerInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler;
+
+/**
+ * ConfigurableCrawlerInterface.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface ConfigurableCrawlerInterface extends CrawlerInterface
+{
+    /**
+     * @param array<string, mixed> $options
+     */
+    public function setOptions(array $options): void;
+}

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -51,9 +51,9 @@ class OutputtingCrawler extends ConcurrentCrawler implements VerboseCrawlerInter
      */
     protected $progress;
 
-    public function __construct()
+    public function __construct(array $options = [])
     {
-        parent::__construct();
+        parent::__construct($options);
         ProgressBar::setFormatDefinition('cache-warmup', self::PROGRESS_BAR_FORMAT);
     }
 

--- a/src/Exception/InvalidCrawlerOptionException.php
+++ b/src/Exception/InvalidCrawlerOptionException.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Exception;
+
+use EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface;
+use RuntimeException;
+
+use function count;
+use function get_class;
+use function implode;
+use function sprintf;
+
+/**
+ * InvalidCrawlerOptionException.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class InvalidCrawlerOptionException extends RuntimeException
+{
+    public static function create(ConfigurableCrawlerInterface $crawler, string $option): self
+    {
+        return new self(
+            sprintf('The crawler option "%s" is invalid or not supported by crawler "%s".', $option, get_class($crawler)),
+            1659120894
+        );
+    }
+
+    /**
+     * @param list<string> $options
+     */
+    public static function createForAll(ConfigurableCrawlerInterface $crawler, array $options): self
+    {
+        if (1 === count($options)) {
+            return self::create($crawler, $options[0]);
+        }
+
+        return new self(
+            sprintf(
+                'The crawler options "%s" are invalid or not supported by crawler "%s".',
+                implode('", "', $options),
+                get_class($crawler)
+            ),
+            1659206995
+        );
+    }
+}

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -330,7 +330,7 @@ final class CacheWarmupCommandTest extends TestCase
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('You\'ve passed crawler options to a non-configurable crawler.', $output);
+        self::assertStringContainsString('You passed crawler options for a non-configurable crawler.', $output);
     }
 
     /**

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -272,6 +272,69 @@ final class CacheWarmupCommandTest extends TestCase
 
     /**
      * @test
+     */
+    public function executeThrowsExceptionIfCrawlerOptionsAreInvalid(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionCode(1659120649);
+        $this->expectExceptionMessage('The given crawler options are invalid. Please pass crawler options as JSON-encoded array.');
+
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--crawler-options' => 'foo',
+        ]);
+    }
+
+    /**
+     * @test
+     * @dataProvider executeUsesCrawlerOptionsDataProvider
+     *
+     * @param array{concurrency: int}|string $crawlerOptions
+     */
+    public function executeUsesCrawlerOptions($crawlerOptions): void
+    {
+        $this->prophesizeSitemapRequest('valid_sitemap_3');
+        $this->commandTester->execute(
+            [
+                'sitemaps' => [
+                    'https://www.example.com/sitemap.xml',
+                ],
+                '--crawler-options' => $crawlerOptions,
+            ],
+            [
+                'verbosity' => OutputInterface::VERBOSITY_VERBOSE,
+            ]
+        );
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('Using custom crawler options:', $output);
+        self::assertStringContainsString('* concurrency: 3', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowsWarningIfCrawlerOptionsArePassedToNonConfigurableCrawler(): void
+    {
+        $this->prophesizeSitemapRequest('valid_sitemap_3');
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--crawler' => DummyCrawler::class,
+            '--crawler-options' => ['foo' => 'bar'],
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('You\'ve passed crawler options to a non-configurable crawler.', $output);
+    }
+
+    /**
+     * @test
      *
      * @throws ClientExceptionInterface
      */
@@ -305,6 +368,15 @@ final class CacheWarmupCommandTest extends TestCase
         ]);
 
         self::assertSame($expected, $exitCode);
+    }
+
+    /**
+     * @return Generator<string, array{array{concurrency: int}|string}>
+     */
+    public function executeUsesCrawlerOptionsDataProvider(): Generator
+    {
+        yield 'array' => [['concurrency' => 3]];
+        yield 'json string' => ['{"concurrency": 3}'];
     }
 
     /**

--- a/tests/Unit/Crawler/AbstractConfigurableCrawlerTest.php
+++ b/tests/Unit/Crawler/AbstractConfigurableCrawlerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler;
+
+use EliasHaeussler\CacheWarmup\Exception\InvalidCrawlerOptionException;
+use PHPUnit\Framework\TestCase;
+
+use function get_class;
+
+/**
+ * AbstractConfigurableCrawlerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class AbstractConfigurableCrawlerTest extends TestCase
+{
+    /**
+     * @var DummyConfigurableCrawler
+     */
+    private $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new DummyConfigurableCrawler();
+    }
+
+    /**
+     * @test
+     */
+    public function defaultOptionsAreUsedOnInitialObject(): void
+    {
+        $expected = [
+            'foo' => 'hello world',
+            'bar' => 42,
+        ];
+
+        self::assertSame($expected, $this->subject->getOptions());
+    }
+
+    /**
+     * @test
+     */
+    public function setOptionsThrowsExceptionIfInvalidOptionsAreGiven(): void
+    {
+        $this->expectException(InvalidCrawlerOptionException::class);
+        $this->expectExceptionCode(1659206995);
+        $this->expectExceptionMessage(
+            'The crawler options "dummy", "blub" are invalid or not supported by crawler "'.get_class($this->subject).'".'
+        );
+
+        $this->subject->setOptions([
+            'foo' => 'bar',
+            'dummy' => 'dummy',
+            'blub' => 'water',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function setOptionsMergesGivenOptionsWithDefaultOptions(): void
+    {
+        $this->subject->setOptions([
+            'foo' => 'bar',
+        ]);
+
+        $expected = [
+            'foo' => 'bar',
+            'bar' => 42,
+        ];
+
+        self::assertSame($expected, $this->subject->getOptions());
+    }
+}

--- a/tests/Unit/Crawler/DummyConfigurableCrawler.php
+++ b/tests/Unit/Crawler/DummyConfigurableCrawler.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler;
+
+use EliasHaeussler\CacheWarmup\Crawler\AbstractConfigurableCrawler;
+
+/**
+ * DummyConfigurableCrawler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ * @extends AbstractConfigurableCrawler<array{foo: string, bar: int}>
+ */
+final class DummyConfigurableCrawler extends AbstractConfigurableCrawler
+{
+    protected static $defaultOptions = [
+        'foo' => 'hello world',
+        'bar' => 42,
+    ];
+
+    public function crawl(array $urls): void
+    {
+        // Intentionally left blank.
+    }
+
+    public function getSuccessfulUrls(): array
+    {
+        return [];
+    }
+
+    public function getFailedUrls(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array{foo: string, bar: int}
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
+++ b/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Exception;
+
+use EliasHaeussler\CacheWarmup\Exception\InvalidCrawlerOptionException;
+use EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\DummyConfigurableCrawler;
+use PHPUnit\Framework\TestCase;
+
+use function get_class;
+
+/**
+ * InvalidCrawlerOptionExceptionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class InvalidCrawlerOptionExceptionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function createReturnsExceptionForGivenCrawlerAndOption(): void
+    {
+        $crawler = new DummyConfigurableCrawler();
+        $actual = InvalidCrawlerOptionException::create($crawler, 'foo');
+
+        self::assertInstanceOf(InvalidCrawlerOptionException::class, $actual);
+        self::assertSame(1659120894, $actual->getCode());
+        self::assertSame(
+            'The crawler option "foo" is invalid or not supported by crawler "'.get_class($crawler).'".',
+            $actual->getMessage()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function createForAllReturnsExceptionForGivenCrawlerAndOptionIfOnlyOneOptionIsGiven(): void
+    {
+        $crawler = new DummyConfigurableCrawler();
+        $actual = InvalidCrawlerOptionException::createForAll($crawler, ['foo']);
+
+        self::assertInstanceOf(InvalidCrawlerOptionException::class, $actual);
+        self::assertSame(1659120894, $actual->getCode());
+        self::assertSame(
+            'The crawler option "foo" is invalid or not supported by crawler "'.get_class($crawler).'".',
+            $actual->getMessage()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function createForAllReturnsExceptionForGivenCrawlerAndOptions(): void
+    {
+        $crawler = new DummyConfigurableCrawler();
+        $options = [
+            'foo',
+            'bar',
+        ];
+
+        $actual = InvalidCrawlerOptionException::createForAll($crawler, $options);
+
+        self::assertInstanceOf(InvalidCrawlerOptionException::class, $actual);
+        self::assertSame(1659206995, $actual->getCode());
+        self::assertSame(
+            'The crawler options "foo", "bar" are invalid or not supported by crawler "'.get_class($crawler).'".',
+            $actual->getMessage()
+        );
+    }
+}


### PR DESCRIPTION
This PR introduces a new interface `EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface`. With this interface, crawlers can be declared to be configurable by a set of crawler options. Additionally, an `EliasHaeussler\CacheWarmup\Crawler\AbstractConfigurableCrawler` was added. It provides basic functionality to parse and handle crawler options.

The default `ConcurrentCrawler` and `OutputtingCrawler` classes have been adjusted to implement said interface. Both crawlers can now be configured through these crawler options:

* **`concurrency`**: Number of concurrent requests (defaults to `5`)
* **`request_method`**: Request method to be used for each single warmup request (defaults to `HEAD`)
* **`request_headers`**: Headers to be sent on each single warmup request (defaults to an empty array)

---

Related issue: #58