### PR TITLE
[FEATURE] Add `o` as shortcut for `--crawler-options` command option

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -161,7 +161,7 @@ final class CacheWarmupCommand extends Command
         );
         $this->addOption(
             'crawler-options',
-            null,
+            'o',
             InputOption::VALUE_REQUIRED,
             'Additional config for configurable crawlers'
         );


### PR DESCRIPTION
The command option `--crawler-options` can now also be used with its shortcut `o`.