### PR TITLE
[TASK] Enable Dependabot for Composer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,15 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 10
+
+  - package-ecosystem: composer
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: friday
+    commit-message:
+      prefix: '[TASK]'
+    labels:
+      - dependencies
+    open-pull-requests-limit: 10
+    versioning-strategy: widen


### PR DESCRIPTION
With this PR, Dependabot now performs updates for Composer dependencies as well.