### PR TITLE
[!!!][FEATURE] Use Symfony Serializer to parse XML sitemaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,9 +143,9 @@ $cacheWarmer->addSitemaps('https://www.example.org/sitemap.xml');
 $cacheWarmer->addSitemaps('https://www.example.org/de/sitemap.xml');
 
 // Define URLs to be crawled
-$cacheWarmer->addUrl(new \GuzzleHttp\Psr7\Uri('https://www.example.org/'));
-$cacheWarmer->addUrl(new \GuzzleHttp\Psr7\Uri('https://www.example.org/foo'));
-$cacheWarmer->addUrl(new \GuzzleHttp\Psr7\Uri('https://www.example.org/baz'));
+$cacheWarmer->addUrl('https://www.example.org/');
+$cacheWarmer->addUrl('https://www.example.org/foo');
+$cacheWarmer->addUrl('https://www.example.org/baz');
 
 // Run cache warmer
 $result = $cacheWarmer->run();

--- a/composer.json
+++ b/composer.json
@@ -16,14 +16,16 @@
 		"php": "~8.1.0",
 		"ext-filter": "*",
 		"ext-json": "*",
-		"ext-libxml": "*",
-		"ext-simplexml": "*",
+		"doctrine/annotations": "^1.13",
 		"guzzlehttp/guzzle": "^7.0",
 		"guzzlehttp/promises": "^1.4",
 		"guzzlehttp/psr7": "^2.0",
 		"psr/http-client": "^1.0",
 		"psr/http-message": "^1.0",
-		"symfony/console": "^6.0"
+		"symfony/console": "^6.1",
+		"symfony/property-access": "^6.1",
+		"symfony/property-info": "^6.1",
+		"symfony/serializer": "^6.1"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,157 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc1848256dd2a6f315310fabe691bf1c",
+    "content-hash": "29dcc73b8c5776bf6a72e1f5b937c6dd",
     "packages": [
+        {
+            "name": "doctrine/annotations",
+            "version": "1.13.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/annotations.git",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
+                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "1.*",
+                "ext-tokenizer": "*",
+                "php": "^7.1 || ^8.0",
+                "psr/cache": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "doctrine/cache": "^1.11 || ^2.0",
+                "doctrine/coding-standard": "^6.0 || ^8.1",
+                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
+                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
+                "symfony/cache": "^4.4 || ^5.2",
+                "vimeo/psalm": "^4.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Benjamin Eberlei",
+                    "email": "kontakt@beberlei.de"
+                },
+                {
+                    "name": "Jonathan Wage",
+                    "email": "jonwage@gmail.com"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "Docblock Annotations Parser",
+            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "parser"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/annotations/issues",
+                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
+            },
+            "time": "2022-07-02T10:48:51+00:00"
+        },
+        {
+            "name": "doctrine/lexer",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9.0",
+                "phpstan/phpstan": "^1.3",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-02-28T11:07:21+00:00"
+        },
         {
             "name": "guzzlehttp/guzzle",
             "version": "7.4.5",
@@ -328,6 +477,55 @@
                 }
             ],
             "time": "2022-06-20T21:43:11+00:00"
+        },
+        {
+            "name": "psr/cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/cache.git",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for caching libraries",
+            "keywords": [
+                "cache",
+                "psr",
+                "psr-6"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/cache/tree/3.0.0"
+            },
+            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/container",
@@ -1080,6 +1278,275 @@
             "time": "2022-05-24T11:49:31+00:00"
         },
         {
+            "name": "symfony/property-access",
+            "version": "v6.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-access.git",
+                "reference": "25108ee9b62d6ef0815007d9c7cf6a7ba40bb7c5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-access/zipball/25108ee9b62d6ef0815007d9c7cf6a7ba40bb7c5",
+                "reference": "25108ee9b62d6ef0815007d9c7cf6a7ba40bb7c5",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/property-info": "^5.4|^6.0"
+            },
+            "require-dev": {
+                "symfony/cache": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "To cache access methods."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyAccess\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides functions to read and write from/to an object or array using a simple string notation",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "access",
+                "array",
+                "extraction",
+                "index",
+                "injection",
+                "object",
+                "property",
+                "property path",
+                "reflection"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-access/tree/v6.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-06-27T17:24:16+00:00"
+        },
+        {
+            "name": "symfony/property-info",
+            "version": "v6.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/property-info.git",
+                "reference": "2fc363ed2f2b5d3b231ed0824e066d140d3fd1d8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/property-info/zipball/2fc363ed2f2b5d3b231ed0824e066d140d3fd1d8",
+                "reference": "2fc363ed2f2b5d3b231ed0824e066d140d3fd1d8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/string": "^5.4|^6.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "<5.2",
+                "phpdocumentor/type-resolver": "<1.5.1",
+                "symfony/dependency-injection": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.10.4",
+                "phpdocumentor/reflection-docblock": "^5.2",
+                "phpstan/phpdoc-parser": "^1.0",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/serializer": "^5.4|^6.0"
+            },
+            "suggest": {
+                "phpdocumentor/reflection-docblock": "To use the PHPDoc",
+                "psr/cache-implementation": "To cache results",
+                "symfony/doctrine-bridge": "To use Doctrine metadata",
+                "symfony/serializer": "To use Serializer metadata"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\PropertyInfo\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Kévin Dunglas",
+                    "email": "dunglas@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Extracts information about PHP class' properties using metadata of popular sources",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "doctrine",
+                "phpdoc",
+                "property",
+                "symfony",
+                "type",
+                "validator"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/property-info/tree/v6.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-19T08:34:05+00:00"
+        },
+        {
+            "name": "symfony/serializer",
+            "version": "v6.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/serializer.git",
+                "reference": "2c59be38d343e2ed4d4ea3c05965c2ae41c7109f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/2c59be38d343e2ed4d4ea3c05965c2ae41c7109f",
+                "reference": "2c59be38d343e2ed4d4ea3c05965c2ae41c7109f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "doctrine/annotations": "<1.12",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/dependency-injection": "<5.4",
+                "symfony/property-access": "<5.4",
+                "symfony/property-info": "<5.4",
+                "symfony/uid": "<5.4",
+                "symfony/yaml": "<5.4"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.12",
+                "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "symfony/cache": "^5.4|^6.0",
+                "symfony/config": "^5.4|^6.0",
+                "symfony/dependency-injection": "^5.4|^6.0",
+                "symfony/error-handler": "^5.4|^6.0",
+                "symfony/filesystem": "^5.4|^6.0",
+                "symfony/form": "^5.4|^6.0",
+                "symfony/http-foundation": "^5.4|^6.0",
+                "symfony/http-kernel": "^5.4|^6.0",
+                "symfony/mime": "^5.4|^6.0",
+                "symfony/property-access": "^5.4|^6.0",
+                "symfony/property-info": "^5.4|^6.0",
+                "symfony/uid": "^5.4|^6.0",
+                "symfony/validator": "^5.4|^6.0",
+                "symfony/var-dumper": "^5.4|^6.0",
+                "symfony/var-exporter": "^5.4|^6.0",
+                "symfony/yaml": "^5.4|^6.0"
+            },
+            "suggest": {
+                "psr/cache-implementation": "For using the metadata cache.",
+                "symfony/config": "For using the XML mapping loader.",
+                "symfony/mime": "For using a MIME type guesser within the DataUriNormalizer.",
+                "symfony/property-access": "For using the ObjectNormalizer.",
+                "symfony/property-info": "To deserialize relations.",
+                "symfony/var-exporter": "For using the metadata compiler.",
+                "symfony/yaml": "For using the default YAML mapping loader."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Serializer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/serializer/tree/v6.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-07-28T22:08:12+00:00"
+        },
+        {
             "name": "symfony/service-contracts",
             "version": "v3.1.1",
             "source": {
@@ -1528,79 +1995,6 @@
             "time": "2022-02-25T21:32:43+00:00"
         },
         {
-            "name": "doctrine/annotations",
-            "version": "1.13.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/annotations.git",
-                "reference": "648b0343343565c4a056bfc8392201385e8d89f0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/annotations/zipball/648b0343343565c4a056bfc8392201385e8d89f0",
-                "reference": "648b0343343565c4a056bfc8392201385e8d89f0",
-                "shasum": ""
-            },
-            "require": {
-                "doctrine/lexer": "1.*",
-                "ext-tokenizer": "*",
-                "php": "^7.1 || ^8.0",
-                "psr/cache": "^1 || ^2 || ^3"
-            },
-            "require-dev": {
-                "doctrine/cache": "^1.11 || ^2.0",
-                "doctrine/coding-standard": "^6.0 || ^8.1",
-                "phpstan/phpstan": "^1.4.10 || ^1.8.0",
-                "phpunit/phpunit": "^7.5 || ^8.0 || ^9.1.5",
-                "symfony/cache": "^4.4 || ^5.2",
-                "vimeo/psalm": "^4.10"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Annotations\\": "lib/Doctrine/Common/Annotations"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Benjamin Eberlei",
-                    "email": "kontakt@beberlei.de"
-                },
-                {
-                    "name": "Jonathan Wage",
-                    "email": "jonwage@gmail.com"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "Docblock Annotations Parser",
-            "homepage": "https://www.doctrine-project.org/projects/annotations.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "parser"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/annotations/issues",
-                "source": "https://github.com/doctrine/annotations/tree/1.13.3"
-            },
-            "time": "2022-07-02T10:48:51+00:00"
-        },
-        {
             "name": "doctrine/instantiator",
             "version": "1.4.1",
             "source": {
@@ -1669,82 +2063,6 @@
                 }
             ],
             "time": "2022-03-03T08:28:38+00:00"
-        },
-        {
-            "name": "doctrine/lexer",
-            "version": "1.2.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/lexer.git",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/lexer/zipball/c268e882d4dbdd85e36e4ad69e02dc284f89d229",
-                "reference": "c268e882d4dbdd85e36e4ad69e02dc284f89d229",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9.0",
-                "phpstan/phpstan": "^1.3",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.11"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Guilherme Blanco",
-                    "email": "guilhermeblanco@gmail.com"
-                },
-                {
-                    "name": "Roman Borschel",
-                    "email": "roman@code-factory.org"
-                },
-                {
-                    "name": "Johannes Schmitt",
-                    "email": "schmittjoh@gmail.com"
-                }
-            ],
-            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
-            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
-            "keywords": [
-                "annotations",
-                "docblock",
-                "lexer",
-                "parser",
-                "php"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/lexer/issues",
-                "source": "https://github.com/doctrine/lexer/tree/1.2.3"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-02-28T11:07:21+00:00"
         },
         {
             "name": "ergebnis/composer-normalize",
@@ -2016,16 +2334,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.9.5",
+            "version": "v3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "4465d70ba776806857a1ac2a6f877e582445ff36"
+                "reference": "76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/4465d70ba776806857a1ac2a6f877e582445ff36",
-                "reference": "4465d70ba776806857a1ac2a6f877e582445ff36",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe",
+                "reference": "76d7da666e66d83a1dc27a9d1c625c80cc4ac1fe",
                 "shasum": ""
             },
             "require": {
@@ -2035,7 +2353,7 @@
                 "ext-json": "*",
                 "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "php-cs-fixer/diff": "^2.0",
+                "sebastian/diff": "^4.0",
                 "symfony/console": "^5.4 || ^6.0",
                 "symfony/event-dispatcher": "^5.4 || ^6.0",
                 "symfony/filesystem": "^5.4 || ^6.0",
@@ -2093,7 +2411,7 @@
             "description": "A tool to automatically fix PHP code style",
             "support": {
                 "issues": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues",
-                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.9.5"
+                "source": "https://github.com/FriendsOfPHP/PHP-CS-Fixer/tree/v3.10.0"
             },
             "funding": [
                 {
@@ -2101,7 +2419,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-07-22T08:43:51+00:00"
+            "time": "2022-08-17T22:13:10+00:00"
         },
         {
             "name": "idiosyncratic/editorconfig",
@@ -2572,58 +2890,6 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
-        },
-        {
-            "name": "php-cs-fixer/diff",
-            "version": "v2.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHP-CS-Fixer/diff.git",
-                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/diff/zipball/29dc0d507e838c4580d018bd8b5cb412474f7ec3",
-                "reference": "29dc0d507e838c4580d018bd8b5cb412474f7ec3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0 || ^8.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.23 || ^6.4.3 || ^7.0",
-                "symfony/process": "^3.3"
-            },
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
-                    "name": "Kore Nordmann",
-                    "email": "mail@kore-nordmann.de"
-                }
-            ],
-            "description": "sebastian/diff v3 backport support for PHP 5.6+",
-            "homepage": "https://github.com/PHP-CS-Fixer",
-            "keywords": [
-                "diff"
-            ],
-            "support": {
-                "issues": "https://github.com/PHP-CS-Fixer/diff/issues",
-                "source": "https://github.com/PHP-CS-Fixer/diff/tree/v2.0.2"
-            },
-            "time": "2020-10-14T08:32:19+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -3505,55 +3771,6 @@
                 }
             ],
             "time": "2022-06-19T12:14:25+00:00"
-        },
-        {
-            "name": "psr/cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
-            },
-            "time": "2021-02-03T23:26:27+00:00"
         },
         {
             "name": "psr/event-dispatcher",
@@ -5621,9 +5838,7 @@
     "platform": {
         "php": "~8.1.0",
         "ext-filter": "*",
-        "ext-json": "*",
-        "ext-libxml": "*",
-        "ext-simplexml": "*"
+        "ext-json": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/src/Exception/InvalidSitemapException.php
+++ b/src/Exception/InvalidSitemapException.php
@@ -24,8 +24,10 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Exception;
 
 use EliasHaeussler\CacheWarmup\Sitemap;
+use Throwable;
 
 use function get_debug_type;
+use function sprintf;
 
 /**
  * InvalidSitemapException.
@@ -35,21 +37,20 @@ use function get_debug_type;
  */
 final class InvalidSitemapException extends Exception
 {
-    public static function forInvalidType(mixed $sitemap): self
+    public static function create(Sitemap\Sitemap $sitemap, Throwable $previous = null): self
     {
         return new self(
-            sprintf('Sitemaps must be of type string or %s, %s given.', Sitemap::class, get_debug_type($sitemap)),
-            1604055096
+            sprintf('The sitemap "%s" is invalid and cannot be parsed.', $sitemap->getUri()),
+            1660668799,
+            $previous
         );
     }
 
-    public static function forEmptyUrl(): self
+    public static function forInvalidType(mixed $sitemap): self
     {
-        return new self('Sitemap URL must not be empty.', 1604055264);
-    }
-
-    public static function forInvalidUrl(): self
-    {
-        return new self('Sitemap must be a valid URL.', 1604055334);
+        return new self(
+            sprintf('Sitemaps must be of type string or %s, %s given.', Sitemap\Sitemap::class, get_debug_type($sitemap)),
+            1604055096
+        );
     }
 }

--- a/src/Exception/InvalidUrlException.php
+++ b/src/Exception/InvalidUrlException.php
@@ -21,48 +21,28 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup;
+namespace EliasHaeussler\CacheWarmup\Exception;
 
-use Psr\Http\Message;
-
-use function filter_var;
-use function trim;
+use function sprintf;
 
 /**
- * Sitemap.
+ * InvalidUrlException.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-class Sitemap
+final class InvalidUrlException extends Exception
 {
-    /**
-     * @throws Exception\InvalidSitemapException
-     */
-    public function __construct(
-        protected Message\UriInterface $uri,
-    ) {
-        $this->validate();
+    public static function create(string $url): self
+    {
+        return new self(
+            sprintf('The given URL "%s" is not valid.', $url),
+            1604055334
+        );
     }
 
-    public function getUri(): Message\UriInterface
+    public static function forEmptyUrl(): self
     {
-        return $this->uri;
-    }
-
-    /**
-     * @throws Exception\InvalidSitemapException
-     */
-    private function validate(): void
-    {
-        $url = (string) $this->uri;
-
-        if ('' === trim($url)) {
-            throw Exception\InvalidSitemapException::forEmptyUrl();
-        }
-
-        if (false === filter_var($url, FILTER_VALIDATE_URL)) {
-            throw Exception\InvalidSitemapException::forInvalidUrl();
-        }
+        return new self('The given URL must not be empty.', 1604055264);
     }
 }

--- a/src/Normalizer/UriDenormalizer.php
+++ b/src/Normalizer/UriDenormalizer.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Normalizer;
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Message;
+use Symfony\Component\PropertyInfo\Type;
+use Symfony\Component\Serializer;
+
+use function in_array;
+use function is_string;
+use function sprintf;
+
+/**
+ * UriDenormalizer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class UriDenormalizer implements Serializer\Normalizer\DenormalizerInterface
+{
+    private const SUPPORTED_TYPES = [
+        Message\UriInterface::class,
+        Psr7\Uri::class,
+    ];
+
+    /**
+     * @template T of Message\UriInterface
+     *
+     * @param class-string<T>                      $type
+     * @param array{deserialization_path?: string} $context
+     *
+     * @return T
+     */
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    {
+        if (!is_string($data)) {
+            throw Serializer\Exception\NotNormalizableValueException::createForUnexpectedDataType(sprintf('The data is not a valid "%s" string representation.', $type), $data, [Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
+        }
+
+        if (Message\UriInterface::class === $type) {
+            $type = Psr7\Uri::class;
+        }
+
+        return new $type($data);
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    {
+        if (!is_string($data)) {
+            return false;
+        }
+
+        return in_array($type, self::SUPPORTED_TYPES, true);
+    }
+}

--- a/src/Result/CrawlingResult.php
+++ b/src/Result/CrawlingResult.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Result;
 
-use Psr\Http\Message\UriInterface;
+use Psr\Http\Message;
 
 /**
  * CrawlingResult.
@@ -37,7 +37,7 @@ final class CrawlingResult
      * @param array<string, mixed> $data
      */
     private function __construct(
-        private readonly UriInterface $uri,
+        private readonly Message\UriInterface $uri,
         private readonly CrawlingState $state,
         private readonly array $data = [],
     ) {
@@ -46,7 +46,7 @@ final class CrawlingResult
     /**
      * @param array<string, mixed> $data
      */
-    public static function createSuccessful(UriInterface $uri, array $data = []): self
+    public static function createSuccessful(Message\UriInterface $uri, array $data = []): self
     {
         return new self($uri, CrawlingState::Successful, $data);
     }
@@ -54,12 +54,12 @@ final class CrawlingResult
     /**
      * @param array<string, mixed> $data
      */
-    public static function createFailed(UriInterface $uri, array $data = []): self
+    public static function createFailed(Message\UriInterface $uri, array $data = []): self
     {
         return new self($uri, CrawlingState::Failed, $data);
     }
 
-    public function getUri(): UriInterface
+    public function getUri(): Message\UriInterface
     {
         return $this->uri;
     }

--- a/src/Sitemap/ChangeFrequency.php
+++ b/src/Sitemap/ChangeFrequency.php
@@ -21,46 +21,21 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
-
-use EliasHaeussler\CacheWarmup\Sitemap;
-use Symfony\Component\Serializer;
+namespace EliasHaeussler\CacheWarmup\Sitemap;
 
 /**
- * ParserResult.
+ * ChangeFrequency.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class ParserResult
+enum ChangeFrequency: string
 {
-    /**
-     * @param list<Sitemap\Sitemap> $sitemaps
-     * @param list<Sitemap\Url>     $urls
-     */
-    public function __construct(
-        #[Serializer\Annotation\SerializedName('sitemap')]
-        private readonly array $sitemaps = [],
-        #[Serializer\Annotation\SerializedName('url')]
-        private readonly array $urls = [],
-    ) {
-    }
-
-    /**
-     * @return list<Sitemap\Sitemap>
-     */
-    public function getSitemaps(): array
-    {
-        return $this->sitemaps;
-    }
-
-    /**
-     * @return list<Sitemap\Url>
-     */
-    public function getUrls(): array
-    {
-        return $this->urls;
-    }
+    case Always = 'always';
+    case Hourly = 'hourly';
+    case Daily = 'daily';
+    case Weekly = 'weekly';
+    case Monthly = 'monthly';
+    case Yearly = 'yearly';
+    case Never = 'never';
 }

--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -21,51 +21,48 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Tests\Unit;
+namespace EliasHaeussler\CacheWarmup\Sitemap;
 
+use DateTimeInterface;
 use EliasHaeussler\CacheWarmup\Exception;
-use EliasHaeussler\CacheWarmup\Sitemap;
-use GuzzleHttp\Psr7;
-use PHPUnit\Framework;
+use Psr\Http\Message;
+use Stringable;
+use Symfony\Component\Serializer;
 
 /**
- * SitemapTest.
+ * Sitemap.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class SitemapTest extends Framework\TestCase
+class Sitemap implements Stringable
 {
-    /**
-     * @test
-     */
-    public function constructorThrowsExceptionIfGivenUriIsEmpty(): void
-    {
-        $this->expectException(Exception\InvalidSitemapException::class);
-        $this->expectExceptionCode(1604055264);
+    use UriValidationTrait;
 
-        new Sitemap(new Psr7\Uri(''));
+    /**
+     * @throws Exception\InvalidUrlException
+     */
+    public function __construct(
+        #[Serializer\Annotation\SerializedName('loc')]
+        protected Message\UriInterface $uri,
+        #[Serializer\Annotation\SerializedName('lastmod')]
+        protected ?DateTimeInterface $lastModificationDate = null,
+    ) {
+        $this->validateUri();
     }
 
-    /**
-     * @test
-     */
-    public function constructorThrowsExceptionIfGivenUriIsNotValid(): void
+    public function getUri(): Message\UriInterface
     {
-        $this->expectException(Exception\InvalidSitemapException::class);
-        $this->expectExceptionCode(1604055334);
-
-        new Sitemap(new Psr7\Uri('foo'));
+        return $this->uri;
     }
 
-    /**
-     * @test
-     */
-    public function constructorAssignsUriCorrectly(): void
+    public function getLastModificationDate(): ?DateTimeInterface
     {
-        $uri = new Psr7\Uri('https://foo.baz');
-        $subject = new Sitemap($uri);
+        return $this->lastModificationDate;
+    }
 
-        self::assertSame($uri, $subject->getUri());
+    public function __toString(): string
+    {
+        return (string) $this->getUri();
     }
 }

--- a/src/Sitemap/UriValidationTrait.php
+++ b/src/Sitemap/UriValidationTrait.php
@@ -21,46 +21,34 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
+namespace EliasHaeussler\CacheWarmup\Sitemap;
 
-use EliasHaeussler\CacheWarmup\Sitemap;
-use Symfony\Component\Serializer;
+use EliasHaeussler\CacheWarmup\Exception;
+use Psr\Http\Message;
 
 /**
- * ParserResult.
+ * UriValidationTrait.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class ParserResult
+trait UriValidationTrait
 {
-    /**
-     * @param list<Sitemap\Sitemap> $sitemaps
-     * @param list<Sitemap\Url>     $urls
-     */
-    public function __construct(
-        #[Serializer\Annotation\SerializedName('sitemap')]
-        private readonly array $sitemaps = [],
-        #[Serializer\Annotation\SerializedName('url')]
-        private readonly array $urls = [],
-    ) {
-    }
+    abstract protected function getUri(): Message\UriInterface;
 
     /**
-     * @return list<Sitemap\Sitemap>
+     * @throws Exception\InvalidUrlException
      */
-    public function getSitemaps(): array
+    protected function validateUri(): void
     {
-        return $this->sitemaps;
-    }
+        $url = (string) $this->getUri();
 
-    /**
-     * @return list<Sitemap\Url>
-     */
-    public function getUrls(): array
-    {
-        return $this->urls;
+        if ('' === trim($url)) {
+            throw Exception\InvalidUrlException::forEmptyUrl();
+        }
+
+        if (false === filter_var($url, FILTER_VALIDATE_URL)) {
+            throw Exception\InvalidUrlException::create($url);
+        }
     }
 }

--- a/src/Sitemap/Url.php
+++ b/src/Sitemap/Url.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Sitemap;
+
+use DateTimeInterface;
+use EliasHaeussler\CacheWarmup\Exception;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message;
+use Symfony\Component\Serializer;
+
+/**
+ * Url.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+class Url extends Psr7\Uri
+{
+    use UriValidationTrait;
+
+    /**
+     * @throws Exception\InvalidUrlException
+     */
+    public function __construct(
+        #[Serializer\Annotation\SerializedName('loc')]
+        protected string $uri,
+        protected float $priority = 0.5,
+        #[Serializer\Annotation\SerializedName('lastmod')]
+        protected ?DateTimeInterface $lastModificationDate = null,
+        #[Serializer\Annotation\SerializedName('changefreq')]
+        protected ?ChangeFrequency $changeFrequency = null,
+    ) {
+        parent::__construct($uri);
+        $this->validateUri();
+    }
+
+    public function getUri(): Message\UriInterface
+    {
+        return $this;
+    }
+
+    public function getPriority(): float
+    {
+        return $this->priority;
+    }
+
+    public function getLastModificationDate(): ?DateTimeInterface
+    {
+        return $this->lastModificationDate;
+    }
+
+    public function getChangeFrequency(): ?ChangeFrequency
+    {
+        return $this->changeFrequency;
+    }
+}

--- a/tests/Unit/Crawler/DummyCrawler.php
+++ b/tests/Unit/Crawler/DummyCrawler.php
@@ -25,7 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler;
 
 use EliasHaeussler\CacheWarmup\Crawler;
 use EliasHaeussler\CacheWarmup\Result;
-use Psr\Http\Message\UriInterface;
+use Psr\Http\Message;
 
 /**
  * DummyCrawler.
@@ -38,7 +38,7 @@ use Psr\Http\Message\UriInterface;
 class DummyCrawler implements Crawler\CrawlerInterface
 {
     /**
-     * @var list<UriInterface>
+     * @var list<Message\UriInterface>
      */
     public static array $crawledUrls = [];
     public static bool $simulateFailure = false;
@@ -61,13 +61,13 @@ class DummyCrawler implements Crawler\CrawlerInterface
     }
 
     /**
-     * @param list<UriInterface> $urls
+     * @param list<Message\UriInterface> $urls
      *
      * @return list<Result\CrawlingResult>
      */
     protected function mapUrlsToCrawlingResults(array $urls, Result\CrawlingState $state): array
     {
-        return array_map(fn (UriInterface $uri): Result\CrawlingResult => match ($state) {
+        return array_map(fn (Message\UriInterface $uri): Result\CrawlingResult => match ($state) {
             Result\CrawlingState::Failed => Result\CrawlingResult::createFailed($uri),
             default => Result\CrawlingResult::createSuccessful($uri),
         }, $urls);

--- a/tests/Unit/Crawler/DummyVerboseCrawler.php
+++ b/tests/Unit/Crawler/DummyVerboseCrawler.php
@@ -24,21 +24,21 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler;
 
 use EliasHaeussler\CacheWarmup\Crawler;
-use Symfony\Component\Console\Output;
+use Symfony\Component\Console;
 
 /**
  * DummyVerboseCrawler.
  *
- * @author Elias Häußler <e.haeussler@familie-redlich.de>
+ * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  *
  * @internal
  */
 final class DummyVerboseCrawler extends DummyCrawler implements Crawler\VerboseCrawlerInterface
 {
-    public static ?Output\OutputInterface $output = null;
+    public static ?Console\Output\OutputInterface $output = null;
 
-    public function setOutput(Output\OutputInterface $output): Crawler\VerboseCrawlerInterface
+    public function setOutput(Console\Output\OutputInterface $output): Crawler\VerboseCrawlerInterface
     {
         self::$output = $output;
 

--- a/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
+++ b/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
@@ -23,9 +23,9 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Tests\Unit\Exception;
 
-use EliasHaeussler\CacheWarmup\Exception\InvalidCrawlerOptionException;
-use EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\DummyConfigurableCrawler;
-use PHPUnit\Framework\TestCase;
+use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Tests;
+use PHPUnit\Framework;
 
 use function get_class;
 
@@ -35,17 +35,17 @@ use function get_class;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class InvalidCrawlerOptionExceptionTest extends TestCase
+final class InvalidCrawlerOptionExceptionTest extends Framework\TestCase
 {
     /**
      * @test
      */
     public function createReturnsExceptionForGivenCrawlerAndOption(): void
     {
-        $crawler = new DummyConfigurableCrawler();
-        $actual = InvalidCrawlerOptionException::create($crawler, 'foo');
+        $crawler = new Tests\Unit\Crawler\DummyConfigurableCrawler();
+        $actual = Exception\InvalidCrawlerOptionException::create($crawler, 'foo');
 
-        self::assertInstanceOf(InvalidCrawlerOptionException::class, $actual);
+        self::assertInstanceOf(Exception\InvalidCrawlerOptionException::class, $actual);
         self::assertSame(1659120894, $actual->getCode());
         self::assertSame(
             'The crawler option "foo" is invalid or not supported by crawler "'.get_class($crawler).'".',
@@ -58,10 +58,10 @@ final class InvalidCrawlerOptionExceptionTest extends TestCase
      */
     public function createForAllReturnsExceptionForGivenCrawlerAndOptionIfOnlyOneOptionIsGiven(): void
     {
-        $crawler = new DummyConfigurableCrawler();
-        $actual = InvalidCrawlerOptionException::createForAll($crawler, ['foo']);
+        $crawler = new Tests\Unit\Crawler\DummyConfigurableCrawler();
+        $actual = Exception\InvalidCrawlerOptionException::createForAll($crawler, ['foo']);
 
-        self::assertInstanceOf(InvalidCrawlerOptionException::class, $actual);
+        self::assertInstanceOf(Exception\InvalidCrawlerOptionException::class, $actual);
         self::assertSame(1659120894, $actual->getCode());
         self::assertSame(
             'The crawler option "foo" is invalid or not supported by crawler "'.get_class($crawler).'".',
@@ -74,15 +74,15 @@ final class InvalidCrawlerOptionExceptionTest extends TestCase
      */
     public function createForAllReturnsExceptionForGivenCrawlerAndOptions(): void
     {
-        $crawler = new DummyConfigurableCrawler();
+        $crawler = new Tests\Unit\Crawler\DummyConfigurableCrawler();
         $options = [
             'foo',
             'bar',
         ];
 
-        $actual = InvalidCrawlerOptionException::createForAll($crawler, $options);
+        $actual = Exception\InvalidCrawlerOptionException::createForAll($crawler, $options);
 
-        self::assertInstanceOf(InvalidCrawlerOptionException::class, $actual);
+        self::assertInstanceOf(Exception\InvalidCrawlerOptionException::class, $actual);
         self::assertSame(1659206995, $actual->getCode());
         self::assertSame(
             'The crawler options "foo", "bar" are invalid or not supported by crawler "'.get_class($crawler).'".',

--- a/tests/Unit/Exception/InvalidSitemapExceptionTest.php
+++ b/tests/Unit/Exception/InvalidSitemapExceptionTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Exception;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+
+use function sprintf;
+
+/**
+ * InvalidSitemapExceptionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class InvalidSitemapExceptionTest extends Framework\TestCase
+{
+    /**
+     * @test
+     */
+    public function createReturnsExceptionForGivenSitemap(): void
+    {
+        $sitemap = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.com'));
+        $actual = Exception\InvalidSitemapException::create($sitemap);
+
+        self::assertInstanceOf(Exception\InvalidSitemapException::class, $actual);
+        self::assertSame(1660668799, $actual->getCode());
+        self::assertSame(
+            'The sitemap "https://www.example.com" is invalid and cannot be parsed.',
+            $actual->getMessage()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function forInvalidTypeReturnsExceptionForGivenSitemap(): void
+    {
+        $actual = Exception\InvalidSitemapException::forInvalidType(null);
+
+        self::assertInstanceOf(Exception\InvalidSitemapException::class, $actual);
+        self::assertSame(1604055096, $actual->getCode());
+        self::assertSame(
+            sprintf('Sitemaps must be of type string or %s, null given.', Sitemap\Sitemap::class),
+            $actual->getMessage()
+        );
+    }
+}

--- a/tests/Unit/Exception/InvalidUrlExceptionTest.php
+++ b/tests/Unit/Exception/InvalidUrlExceptionTest.php
@@ -21,46 +21,40 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Exception;
 
-use EliasHaeussler\CacheWarmup\Sitemap;
-use Symfony\Component\Serializer;
+use EliasHaeussler\CacheWarmup\Exception;
+use PHPUnit\Framework;
 
 /**
- * ParserResult.
+ * InvalidUrlExceptionTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class ParserResult
+final class InvalidUrlExceptionTest extends Framework\TestCase
 {
     /**
-     * @param list<Sitemap\Sitemap> $sitemaps
-     * @param list<Sitemap\Url>     $urls
+     * @test
      */
-    public function __construct(
-        #[Serializer\Annotation\SerializedName('sitemap')]
-        private readonly array $sitemaps = [],
-        #[Serializer\Annotation\SerializedName('url')]
-        private readonly array $urls = [],
-    ) {
+    public function createReturnsExceptionForGivenUrl(): void
+    {
+        $actual = Exception\InvalidUrlException::create('foo');
+
+        self::assertInstanceOf(Exception\InvalidUrlException::class, $actual);
+        self::assertSame(1604055334, $actual->getCode());
+        self::assertSame('The given URL "foo" is not valid.', $actual->getMessage());
     }
 
     /**
-     * @return list<Sitemap\Sitemap>
+     * @test
      */
-    public function getSitemaps(): array
+    public function forEmptyUrlReturnsExceptionIfUrlIsEmpty(): void
     {
-        return $this->sitemaps;
-    }
+        $actual = Exception\InvalidUrlException::forEmptyUrl();
 
-    /**
-     * @return list<Sitemap\Url>
-     */
-    public function getUrls(): array
-    {
-        return $this->urls;
+        self::assertInstanceOf(Exception\InvalidUrlException::class, $actual);
+        self::assertSame(1604055264, $actual->getCode());
+        self::assertSame('The given URL must not be empty.', $actual->getMessage());
     }
 }

--- a/tests/Unit/Exception/MissingArgumentExceptionTest.php
+++ b/tests/Unit/Exception/MissingArgumentExceptionTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Exception;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use Generator;
+use PHPUnit\Framework;
+
+use function sprintf;
+
+/**
+ * MissingArgumentExceptionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class MissingArgumentExceptionTest extends Framework\TestCase
+{
+    /**
+     * @test
+     * @dataProvider createReturnsExceptionForGivenArgumentNameDataProvider
+     */
+    public function createReturnsExceptionForGivenArgumentName(string $argumentName, string $expected): void
+    {
+        $actual = Exception\MissingArgumentException::create($argumentName);
+        $expectedMessage = sprintf('Required argument "$%s" is missing.', $expected);
+
+        self::assertInstanceOf(Exception\MissingArgumentException::class, $actual);
+        self::assertSame(1619635638, $actual->getCode());
+        self::assertSame($expectedMessage, $actual->getMessage());
+    }
+
+    /**
+     * @return Generator<string, array{string, string}>
+     */
+    public function createReturnsExceptionForGivenArgumentNameDataProvider(): Generator
+    {
+        yield 'name only' => ['foo', 'foo'];
+        yield 'name with dollar sign' => ['$foo', 'foo'];
+    }
+}

--- a/tests/Unit/Fixtures/invalid_sitemap_2.xml
+++ b/tests/Unit/Fixtures/invalid_sitemap_2.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-        <foo />
+        <loc>foo</loc>
     </url>
     <url>
         <loc>https://www.example.org/foo</loc>

--- a/tests/Unit/Fixtures/valid_sitemap_4.xml
+++ b/tests/Unit/Fixtures/valid_sitemap_4.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+    <sitemap>
+        <loc>https://www.example.org/sitemap_en.xml</loc>
+        <lastmod>2022-08-17T13:18:06+02:00</lastmod>
+    </sitemap>
+</sitemapindex>

--- a/tests/Unit/Fixtures/valid_sitemap_5.xml
+++ b/tests/Unit/Fixtures/valid_sitemap_5.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="https://www.sitemaps.org/schemas/sitemap/0.9">
+    <url>
+        <loc>https://www.example.org/</loc>
+        <priority>0.8</priority>
+        <lastmod>2022-05-02T12:14:44+02:00</lastmod>
+        <changefreq>yearly</changefreq>
+    </url>
+    <url>
+        <loc>https://www.example.org/foo</loc>
+        <priority>0.5</priority>
+        <lastmod>2021-06-07T20:01:25+02:00</lastmod>
+        <changefreq>monthly</changefreq>
+    </url>
+    <url>
+        <loc>https://www.example.org/baz</loc>
+        <priority>0.5</priority>
+        <lastmod>2021-05-28T11:54:00+02:00</lastmod>
+        <changefreq>hourly</changefreq>
+    </url>
+</urlset>

--- a/tests/Unit/Normalizer/UriDenormalizerTest.php
+++ b/tests/Unit/Normalizer/UriDenormalizerTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Normalizer;
+
+use EliasHaeussler\CacheWarmup\Normalizer;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use Generator;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+use Psr\Http\Message;
+use Symfony\Component\Serializer;
+
+use function sprintf;
+
+/**
+ * UriDenormalizerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class UriDenormalizerTest extends Framework\TestCase
+{
+    private Normalizer\UriDenormalizer $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Normalizer\UriDenormalizer();
+    }
+
+    /**
+     * @test
+     */
+    public function denormalizeThrowsExceptionIfGivenDataIsNotAString(): void
+    {
+        $this->expectException(Serializer\Exception\NotNormalizableValueException::class);
+        $this->expectExceptionMessage(sprintf('The data is not a valid "%s" string representation.', Message\UriInterface::class));
+
+        $this->subject->denormalize(null, Message\UriInterface::class);
+    }
+
+    /**
+     * @test
+     * @dataProvider denormalizeReturnsDenormalizedUriDataProvider
+     *
+     * @param class-string<Message\UriInterface> $type
+     */
+    public function denormalizeReturnsDenormalizedUri(string $type, Message\UriInterface $expected): void
+    {
+        self::assertEquals($expected, $this->subject->denormalize('https://www.example.com', $type));
+    }
+
+    /**
+     * @test
+     */
+    public function supportsDenormalizationReturnsFalseIfGivenDataIsNotAString(): void
+    {
+        self::assertFalse($this->subject->supportsDenormalization(null, Message\UriInterface::class));
+    }
+
+    /**
+     * @test
+     * @dataProvider supportsDenormalizationChecksIfGivenTypeIsSupportedDataProvider
+     *
+     * @param class-string<Message\UriInterface> $type
+     */
+    public function supportsDenormalizationChecksIfGivenTypeIsSupported(string $type, bool $expected): void
+    {
+        self::assertSame($expected, $this->subject->supportsDenormalization('foo', $type));
+    }
+
+    /**
+     * @return Generator<string, array{class-string<Message\UriInterface>, Message\UriInterface}>
+     */
+    public function denormalizeReturnsDenormalizedUriDataProvider(): Generator
+    {
+        $url = 'https://www.example.com';
+
+        yield Message\UriInterface::class => [Message\UriInterface::class, new Psr7\Uri($url)];
+        yield Psr7\Uri::class => [Psr7\Uri::class, new Psr7\Uri($url)];
+    }
+
+    /**
+     * @return Generator<string, array{class-string<Message\UriInterface>, bool}>
+     */
+    public function supportsDenormalizationChecksIfGivenTypeIsSupportedDataProvider(): Generator
+    {
+        yield Message\UriInterface::class => [Message\UriInterface::class, true];
+        yield Psr7\Uri::class => [Psr7\Uri::class, true];
+        yield Sitemap\Url::class => [Sitemap\Url::class, false];
+    }
+}

--- a/tests/Unit/Result/ParserResultTest.php
+++ b/tests/Unit/Result/ParserResultTest.php
@@ -40,62 +40,43 @@ final class ParserResultTest extends Framework\TestCase
 
     protected function setUp(): void
     {
-        $this->subject = new Result\ParserResult();
+        $sitemaps = [
+            new Sitemap\Sitemap(new Psr7\Uri('https://www.example.com/')),
+            new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/')),
+        ];
+        $urls = [
+            new Sitemap\Url('https://www.example.com/'),
+            new Sitemap\Url('https://www.example.org/'),
+        ];
+
+        $this->subject = new Result\ParserResult($sitemaps, $urls);
     }
 
     /**
      * @test
      */
-    public function addAddsSitemapToResult(): void
+    public function getSitemapsReturnsSitemaps(): void
     {
-        $sitemap = new Sitemap(new Psr7\Uri('https://www.example.com'));
-
-        self::assertSame([], $this->subject->getSitemaps());
-
-        $this->subject->add($sitemap);
-
-        self::assertSame([$sitemap], $this->subject->getSitemaps());
+        self::assertEquals(
+            [
+                new Sitemap\Sitemap(new Psr7\Uri('https://www.example.com/')),
+                new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/')),
+            ],
+            $this->subject->getSitemaps()
+        );
     }
 
     /**
      * @test
      */
-    public function addAddsUrlToResult(): void
+    public function getUrlsReturnsUrls(): void
     {
-        $url = new Psr7\Uri('https://www.example.com');
-
-        self::assertSame([], $this->subject->getUrls());
-
-        $this->subject->add($url);
-
-        self::assertSame([$url], $this->subject->getUrls());
-    }
-
-    /**
-     * @test
-     */
-    public function addSitemapAddsSitemapToResult(): void
-    {
-        $sitemap = new Sitemap(new Psr7\Uri('https://www.example.com'));
-
-        self::assertSame([], $this->subject->getSitemaps());
-
-        $this->subject->addSitemap($sitemap);
-
-        self::assertSame([$sitemap], $this->subject->getSitemaps());
-    }
-
-    /**
-     * @test
-     */
-    public function addUrlAddsUrlToResult(): void
-    {
-        $url = new Psr7\Uri('https://www.example.com');
-
-        self::assertSame([], $this->subject->getUrls());
-
-        $this->subject->addUrl($url);
-
-        self::assertSame([$url], $this->subject->getUrls());
+        self::assertEquals(
+            [
+                new Sitemap\Url('https://www.example.com/'),
+                new Sitemap\Url('https://www.example.org/'),
+            ],
+            $this->subject->getUrls()
+        );
     }
 }

--- a/tests/Unit/Sitemap/SitemapTest.php
+++ b/tests/Unit/Sitemap/SitemapTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Sitemap;
+
+use DateTimeImmutable;
+use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+
+/**
+ * SitemapTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SitemapTest extends Framework\TestCase
+{
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfGivenUriIsEmpty(): void
+    {
+        $this->expectException(Exception\InvalidUrlException::class);
+        $this->expectExceptionCode(1604055264);
+        $this->expectExceptionMessage('The given URL must not be empty.');
+
+        new Sitemap\Sitemap(new Psr7\Uri(''));
+    }
+
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfGivenUriIsNotValid(): void
+    {
+        $this->expectException(Exception\InvalidUrlException::class);
+        $this->expectExceptionCode(1604055334);
+        $this->expectExceptionMessage('The given URL "foo" is not valid.');
+
+        new Sitemap\Sitemap(new Psr7\Uri('foo'));
+    }
+
+    /**
+     * @test
+     */
+    public function constructorAssignsUriCorrectly(): void
+    {
+        $uri = new Psr7\Uri('https://foo.baz');
+        $subject = new Sitemap\Sitemap($uri);
+
+        self::assertSame($uri, $subject->getUri());
+    }
+
+    /**
+     * @test
+     */
+    public function constructorAssignsLastModificationDateCorrectly(): void
+    {
+        $uri = new Psr7\Uri('https://foo.baz');
+        $lastModificationDate = (new DateTimeImmutable())->modify('- 1 day');
+        $subject = new Sitemap\Sitemap($uri, $lastModificationDate);
+
+        self::assertSame($lastModificationDate, $subject->getLastModificationDate());
+    }
+
+    /**
+     * @test
+     */
+    public function stringRepresentationReturnsUri(): void
+    {
+        $uri = new Psr7\Uri('https://foo.baz');
+        $subject = new Sitemap\Sitemap($uri);
+
+        self::assertSame((string) $uri, (string) $subject);
+    }
+}

--- a/tests/Unit/Sitemap/UrlTest.php
+++ b/tests/Unit/Sitemap/UrlTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Sitemap;
+
+use DateTimeImmutable;
+use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use PHPUnit\Framework;
+
+/**
+ * UrlTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class UrlTest extends Framework\TestCase
+{
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfGivenUriIsEmpty(): void
+    {
+        $this->expectException(Exception\InvalidUrlException::class);
+        $this->expectExceptionCode(1604055264);
+        $this->expectExceptionMessage('The given URL must not be empty.');
+
+        new Sitemap\Url('');
+    }
+
+    /**
+     * @test
+     */
+    public function constructorThrowsExceptionIfGivenUriIsNotValid(): void
+    {
+        $this->expectException(Exception\InvalidUrlException::class);
+        $this->expectExceptionCode(1604055334);
+        $this->expectExceptionMessage('The given URL "foo" is not valid.');
+
+        new Sitemap\Url('foo');
+    }
+
+    /**
+     * @test
+     */
+    public function constructorAssignsUriCorrectly(): void
+    {
+        $subject = new Sitemap\Url('https://foo.baz');
+
+        self::assertSame($subject, $subject->getUri());
+    }
+
+    /**
+     * @test
+     */
+    public function constructorAssignsPriorityCorrectly(): void
+    {
+        $priority = 0.8;
+        $subject = new Sitemap\Url('https://foo.baz', priority: $priority);
+
+        self::assertSame($priority, $subject->getPriority());
+    }
+
+    /**
+     * @test
+     */
+    public function constructorAssignsLastModificationDateCorrectly(): void
+    {
+        $lastModificationDate = (new DateTimeImmutable())->modify('- 1 day');
+        $subject = new Sitemap\Url('https://foo.baz', lastModificationDate: $lastModificationDate);
+
+        self::assertSame($lastModificationDate, $subject->getLastModificationDate());
+    }
+
+    /**
+     * @test
+     */
+    public function constructorAssignsChangeFrequencyCorrectly(): void
+    {
+        $changeFrequency = Sitemap\ChangeFrequency::Hourly;
+        $subject = new Sitemap\Url('https://foo.baz', changeFrequency: $changeFrequency);
+
+        self::assertSame($changeFrequency, $subject->getChangeFrequency());
+    }
+}


### PR DESCRIPTION
With this PR, parsing XML sitemaps is now more robust. This is achieved by the usage of the `symfony/serializer` component along with comprehensive value objects for all parsed sitemap components:

- Sitemap indexes: `EliasHaeussler\CacheWarmup\Sitemap\Sitemap`
- Sitemap URLs: `EliasHaeussler\CacheWarmup\Sitemap\Url`

Additionally, the cache warmer can now be used in strict (default) or non-strict mode. Strict mode means, as soon as a sitemap cannot be parsed, an appropriate exception is thrown. When running the cache warmer in non-strict mode, parser errors will be ignored and the appropriate sitemap is added to the `$cacheWarmer->failedSitemaps` property.

Next to that, the value objects are now populated with more properties from the XML sitemap as before. Take a look at the classes to get an overview about which properties are now available after parsing.