### PR TITLE
[BUGFIX] Run `composer install` in CI

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -28,7 +28,7 @@ jobs:
 
       # Install dependencies
       - name: Install Composer dependencies
-        run: composer update --no-progress
+        uses: ramsey/composer-install@v2
 
       # Check Composer dependencies
       - name: Check dependencies

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install box
         run: phive install --trust-gpg-keys 2DF45277AEF09A2F humbug/box
       - name: Install Composer dependencies
-        run: composer update --no-progress
+        uses: ramsey/composer-install@v2
       - name: Compile PHAR
         run: ./tools/box compile --with-docker
 


### PR DESCRIPTION
Since fe26e62ee76c86d9ecc0c074428d2bb09c5b644e, the `composer.lock` file is present in this repository. Therefore, CI should perform `composer install` instead of `composer update` since Dependabot takes care of updating dependencies.