### PR TITLE
[FEATURE] Make `--progress` command option negatable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Please have a look at [`Usage with Docker`](#usage-with-docker).
 ./vendor/bin/cache-warmup \
   [--urls=URLS...] \
   [--limit=LIMIT] \
-  [--progress] \
+  [--[no-]progress] \
   [--crawler=CRAWLER] \
   [--crawler-options=CRAWLER-OPTIONS] \
   [--allow-failures] \
@@ -84,8 +84,8 @@ Please have a look at [`Usage with Docker`](#usage-with-docker).
 # Limit number of pages to be crawled
 ./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --limit 50
 
-# Show progress bar (can also be achieved by increasing verbosity)
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --progress
+# Show or hide progress bar (progress bar is shown by default with increased verbosity)
+./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --[no-]progress
 ./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" -v
 
 # Use custom crawler (must implement EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface)

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
 		"phpspec/prophecy-phpunit": "^2.0",
 		"phpstan/phpstan": "^1.8",
 		"phpstan/phpstan-phpunit": "^1.1",
-		"phpstan/phpstan-symfony": "^1.2",
+		"phpstan/phpstan-symfony": "^1.2.11",
 		"phpunit/phpunit": "^9.5"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "29dcc73b8c5776bf6a72e1f5b937c6dd",
+    "content-hash": "1e153f3b940b50687a2df3f5265a1143",
     "packages": [
         {
             "name": "doctrine/annotations",
@@ -3283,16 +3283,16 @@
         },
         {
             "name": "phpstan/phpstan-symfony",
-            "version": "1.2.9",
+            "version": "1.2.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-symfony.git",
-                "reference": "f4cb3b8915d3656e780f305f01c86b70ff933272"
+                "reference": "a14d467083e8a4ca6860921e68f646831a88260c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/f4cb3b8915d3656e780f305f01c86b70ff933272",
-                "reference": "f4cb3b8915d3656e780f305f01c86b70ff933272",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/a14d467083e8a4ca6860921e68f646831a88260c",
+                "reference": "a14d467083e8a4ca6860921e68f646831a88260c",
                 "shasum": ""
             },
             "require": {
@@ -3310,15 +3310,15 @@
                 "phpstan/phpstan-strict-rules": "^1.0",
                 "phpunit/phpunit": "^9.5",
                 "psr/container": "1.0 || 1.1.1",
-                "symfony/config": "^4.2 || ^5.0",
-                "symfony/console": "^4.0 || ^5.0",
-                "symfony/dependency-injection": "^4.0 || ^5.0",
-                "symfony/form": "^4.0 || ^5.0",
-                "symfony/framework-bundle": "^4.4 || ^5.0",
-                "symfony/http-foundation": "^5.1",
-                "symfony/messenger": "^4.2 || ^5.0",
+                "symfony/config": "^5.4 || ^6.1",
+                "symfony/console": "^5.4 || ^6.1",
+                "symfony/dependency-injection": "^5.4 || ^6.1",
+                "symfony/form": "^5.4 || ^6.1",
+                "symfony/framework-bundle": "^5.4 || ^6.1",
+                "symfony/http-foundation": "^5.4 || ^6.1",
+                "symfony/messenger": "^5.4",
                 "symfony/polyfill-php80": "^1.24",
-                "symfony/serializer": "^4.0 || ^5.0"
+                "symfony/serializer": "^5.4"
             },
             "type": "phpstan-extension",
             "extra": {
@@ -3348,9 +3348,9 @@
             "description": "Symfony Framework extensions and rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-symfony/issues",
-                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.2.9"
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.2.11"
             },
-            "time": "2022-08-05T20:13:38+00:00"
+            "time": "2022-08-25T20:39:28+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -138,7 +138,7 @@ final class CacheWarmupCommand extends Console\Command\Command
         $this->addOption(
             'progress',
             'p',
-            Console\Input\InputOption::VALUE_NONE,
+            Console\Input\InputOption::VALUE_NEGATABLE,
             'Show progress bar during cache warmup'
         );
         $this->addOption(
@@ -316,7 +316,7 @@ final class CacheWarmupCommand extends Console\Command\Command
 
             /** @var Crawler\CrawlerInterface $crawler */
             $crawler = new $crawler();
-        } elseif ($output->isVerbose() || $input->getOption('progress')) {
+        } elseif ($this->isProgressBarEnabled($output, $input)) {
             // Use default verbose crawler
             $crawler = new Crawler\OutputtingCrawler();
         } else {
@@ -342,6 +342,17 @@ final class CacheWarmupCommand extends Console\Command\Command
         }
 
         return $crawler;
+    }
+
+    private function isProgressBarEnabled(
+        Console\Output\OutputInterface $output,
+        Console\Input\InputInterface $input,
+        ): bool {
+        if (false === $input->getOption('progress')) {
+            return false;
+        }
+
+        return $output->isVerbose() || $input->getOption('progress');
     }
 
     /**

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -202,6 +202,49 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     /**
      * @test
      */
+    public function executeHidesVerboseOutputIfNoProgressOptionIsSet(): void
+    {
+        $this->prophesizeSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute(
+            [
+                'sitemaps' => [
+                    'https://www.example.com/sitemap.xml',
+                ],
+                '--no-progress' => true,
+            ],
+            [
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERBOSE,
+            ]
+        );
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringNotContainsString('100%', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function executeShowsVerboseOutputIfProgressOptionIsSet(): void
+    {
+        $this->prophesizeSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--progress' => true,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString('100%', $output);
+    }
+
+    /**
+     * @test
+     */
     public function executeThrowsExceptionIfGivenCrawlerClassDoesNotExist(): void
     {
         $this->expectException(Console\Exception\RuntimeException::class);


### PR DESCRIPTION
With this PR, the command option `--progress` is now negatable. Progress bars can now explicitly disabled by passing `--no-progress` to the cache warmup command.