### PR TITLE
[BUGFIX] Skip PHP compactor for phar files

### DIFF
--- a/box.json
+++ b/box.json
@@ -1,7 +1,6 @@
 {
     "compactors": [
-        "KevinGH\\Box\\Compactor\\Json",
-        "KevinGH\\Box\\Compactor\\Php"
+        "KevinGH\\Box\\Compactor\\Json"
     ],
     "compression": "GZ",
     "output": ".build/cache-warmup.phar"


### PR DESCRIPTION
We cannot use the PHP compactor when building phar files, otherwise relevant phpdoc comments will be stripped off. This leads to failing denormalization when parsing XML sitemaps.