### PR TITLE
[BUGFIX] Loosen strict enumerations for change frequency

### DIFF
--- a/src/Normalizer/ChangeFrequencyNormalizer.php
+++ b/src/Normalizer/ChangeFrequencyNormalizer.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Normalizer;
+
+use EliasHaeussler\CacheWarmup\Sitemap;
+use Symfony\Component\PropertyInfo;
+use Symfony\Component\Serializer;
+use ValueError;
+
+use function is_string;
+
+/**
+ * ChangeFrequencyNormalizer.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ChangeFrequencyNormalizer implements Serializer\Normalizer\DenormalizerInterface
+{
+    /**
+     * @param array{deserialization_path?: string} $context
+     */
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = [])
+    {
+        if (!is_string($data)) {
+            throw Serializer\Exception\NotNormalizableValueException::createForUnexpectedDataType('Change frequency data must be a string.', $data, [PropertyInfo\Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true);
+        }
+
+        try {
+            return Sitemap\ChangeFrequency::fromCaseInsensitive($data);
+        } catch (ValueError $error) {
+            throw Serializer\Exception\NotNormalizableValueException::createForUnexpectedDataType($error->getMessage(), $data, [PropertyInfo\Type::BUILTIN_TYPE_STRING], $context['deserialization_path'] ?? null, true, $error->getCode(), $error);
+        }
+    }
+
+    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    {
+        return Sitemap\ChangeFrequency::class === $type;
+    }
+}

--- a/src/Sitemap/ChangeFrequency.php
+++ b/src/Sitemap/ChangeFrequency.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Sitemap;
 
+use function strtolower;
+
 /**
  * ChangeFrequency.
  *
@@ -38,4 +40,9 @@ enum ChangeFrequency: string
     case Monthly = 'monthly';
     case Yearly = 'yearly';
     case Never = 'never';
+
+    public static function fromCaseInsensitive(string $changeFrequency): self
+    {
+        return self::from(strtolower($changeFrequency));
+    }
 }

--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -67,7 +67,7 @@ final class XmlParser
                 new Serializer\Normalizer\DateTimeNormalizer([
                     Serializer\Normalizer\DateTimeNormalizer::FORMAT_KEY => DateTimeInterface::W3C,
                 ]),
-                new Serializer\Normalizer\BackedEnumNormalizer(),
+                new Normalizer\ChangeFrequencyNormalizer(),
                 new Serializer\Normalizer\ObjectNormalizer(
                     $classMetadataFactory = new Serializer\Mapping\Factory\ClassMetadataFactory(
                         new Serializer\Mapping\Loader\AnnotationLoader(new Annotations\AnnotationReader())

--- a/tests/Unit/Normalizer/ChangeFrequencyNormalizerTest.php
+++ b/tests/Unit/Normalizer/ChangeFrequencyNormalizerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2022 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Normalizer;
+
+use EliasHaeussler\CacheWarmup\Normalizer;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use Generator;
+use PHPUnit\Framework;
+use Symfony\Component\Serializer;
+
+/**
+ * ChangeFrequencyNormalizerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ChangeFrequencyNormalizerTest extends Framework\TestCase
+{
+    private Normalizer\ChangeFrequencyNormalizer $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Normalizer\ChangeFrequencyNormalizer();
+    }
+
+    /**
+     * @test
+     */
+    public function denormalizeThrowsExceptionIfGivenDataIsNotAString(): void
+    {
+        $this->expectException(Serializer\Exception\NotNormalizableValueException::class);
+
+        $this->subject->denormalize(null, Sitemap\ChangeFrequency::class);
+    }
+
+    /**
+     * @test
+     */
+    public function denormalizeThrowsExceptionIfGivenDataCannotBeDenormalized(): void
+    {
+        $this->expectException(Serializer\Exception\NotNormalizableValueException::class);
+
+        $this->subject->denormalize('foo', Sitemap\ChangeFrequency::class);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider denormalizeReturnsDenormalizedDataDataProvider
+     */
+    public function denormalizeReturnsDenormalizedData(string $data, Sitemap\ChangeFrequency $expected): void
+    {
+        self::assertSame($expected, $this->subject->denormalize($data, Sitemap\ChangeFrequency::class));
+    }
+
+    /**
+     * @test
+     */
+    public function supportsDenormalizationReturnsTrueIfGivenTypeIsChangeFrequency(): void
+    {
+        self::assertTrue($this->subject->supportsDenormalization('foo', Sitemap\ChangeFrequency::class));
+        self::assertFalse($this->subject->supportsDenormalization('foo', 'baz'));
+    }
+
+    /**
+     * @return Generator<string, array{string, Sitemap\ChangeFrequency}>
+     */
+    public function denormalizeReturnsDenormalizedDataDataProvider(): Generator
+    {
+        yield 'supported value' => ['monthly', Sitemap\ChangeFrequency::Monthly];
+        yield 'case-insensitive value' => ['Monthly', Sitemap\ChangeFrequency::Monthly];
+    }
+}


### PR DESCRIPTION
With this PR, the value of the `changefreq` node can now be case-insensitive. That means, the following XML can now be parsed correctly:

```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  <url>
    <loc>https://www.google.com/forms/about/</loc>
    <changefreq>Weekly</changefreq>
    <priority>0.8</priority>
  </url>
</urlset>
```

(Source: https://www.google.com/forms/sitemaps.xml)