### PR TITLE
[TASK] Remove Docker build schedule

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,6 @@ on:
   push:
     tags:
       - '*'
-  schedule:
-    # Run every day at 02:23
-    - cron: '23 2 * * *'
   workflow_dispatch:
 
 jobs:
@@ -19,7 +16,7 @@ jobs:
 
       # Check if tag is valid
       - name: Check tag
-        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
             exit 1
@@ -60,7 +57,7 @@ jobs:
 
       # Check if tag is valid
       - name: Check tag
-        if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         run: |
           if ! [[ ${{ github.ref }} =~ ^refs/tags/[0-9]{1,3}.[0-9]{1,3}.[0-9]{1,3}$ ]]; then
             exit 1
@@ -110,7 +107,7 @@ jobs:
   # Job: Create release
   release:
     name: Create release
-    if: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ github.event_name != 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: phar
     steps:


### PR DESCRIPTION
The Docker build schedule was added when we did not have a `composer.lock` committed. Since this file is now committed and every build is equal, the schedule is no longer relevant and thus removed.