### PR TITLE
[FEATURE] Make crawler client configurable in default crawlers

### DIFF
--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -41,7 +41,8 @@ use Throwable;
  * @extends AbstractConfigurableCrawler<array{
  *     concurrency: int,
  *     request_method: string,
- *     request_headers: array<string, string>
+ *     request_headers: array<string, string>,
+ *     client_config: array<string, mixed>
  * }>
  */
 class ConcurrentCrawler extends AbstractConfigurableCrawler
@@ -50,13 +51,17 @@ class ConcurrentCrawler extends AbstractConfigurableCrawler
         'concurrency' => 5,
         'request_method' => 'HEAD',
         'request_headers' => [],
+        'client_config' => [],
     ];
+
+    protected readonly ClientInterface $client;
 
     public function __construct(
         array $options = [],
-        protected readonly ClientInterface $client = new Client(),
+        ClientInterface $client = null,
     ) {
         parent::__construct($options);
+        $this->client = null !== $client ? $client : new Client($this->options['client_config']);
     }
 
     public function crawl(array $urls): Result\CacheWarmupResult

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\CacheWarmup\Crawler;
 
 use EliasHaeussler\CacheWarmup\Exception;
 use EliasHaeussler\CacheWarmup\Result;
-use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use Psr\Http\Message;
 use Symfony\Component\Console;
@@ -49,7 +48,7 @@ class OutputtingCrawler extends ConcurrentCrawler implements VerboseCrawlerInter
 
     public function __construct(
         array $options = [],
-        ClientInterface $client = new Client(),
+        ClientInterface $client = null,
     ) {
         parent::__construct($options, $client);
         Console\Helper\ProgressBar::setFormatDefinition('cache-warmup', self::PROGRESS_BAR_FORMAT);


### PR DESCRIPTION
This PR adds a new crawler configuration `client_config` to the default crawlers, `ConcurrentCrawler` and `OutputtingCrawler`. This configuration allows to pass individual config to the initialized Guzzle client. However, it is still possible to pass a custom client object. In this case, the new `client_config` option is ignored.