### PR TITLE
[FEATURE] Make crawler client configurable in default crawlers

### DIFF
--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -42,7 +42,8 @@ use Throwable;
  * @extends AbstractConfigurableCrawler<array{
  *     concurrency: int,
  *     request_method: string,
- *     request_headers: array<string, string>
+ *     request_headers: array<string, string>,
+ *     client_config: array<string, mixed>
  * }>
  */
 class ConcurrentCrawler extends AbstractConfigurableCrawler
@@ -51,6 +52,7 @@ class ConcurrentCrawler extends AbstractConfigurableCrawler
         'concurrency' => 5,
         'request_method' => 'HEAD',
         'request_headers' => [],
+        'client_config' => [],
     ];
 
     /**
@@ -125,7 +127,7 @@ class ConcurrentCrawler extends AbstractConfigurableCrawler
 
     protected function initializeClient(): ClientInterface
     {
-        return new Client();
+        return new Client($this->options['client_config']);
     }
 
     /**


### PR DESCRIPTION
This commit adds a new crawler configuration `client_config` to the default crawlers, `ConcurrentCrawler` and `OutputtingCrawler`. This configuration allows to pass individual config to the initialized Guzzle client.