### PR TITLE
[TASK] Run Dependabot auto-merge only when PR is opened

### DIFF
--- a/.github/workflows/auto-merge.yaml
+++ b/.github/workflows/auto-merge.yaml
@@ -1,5 +1,7 @@
 name: Dependabot auto-merge
-on: [pull_request]
+on:
+  pull_request:
+    types: [opened]
 
 jobs:
   dependabot-auto-merge:


### PR DESCRIPTION
With this PR, the Dependabot auto-merge workflow only runs when a PR is opened.