### PR TITLE
[BUGFIX] Disable Docker tag `latest` for 0.8.x branch

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
         with:
           images: eliashaeussler/cache-warmup
           tags: |
-            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value=latest,enable=false
             type=semver,pattern={{version}}
             type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
 


### PR DESCRIPTION
The `latest` tag must only be used for the default branch.