### PR TITLE
[TASK] Check `composer.lock` when running `composer normalize`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
 			"@lint:php:fix"
 		],
 		"lint:composer": "@lint:composer:fix --dry-run",
-		"lint:composer:fix": "@composer normalize --no-check-lock --no-update-lock",
+		"lint:composer:fix": "@composer normalize",
 		"lint:editorconfig": "ec",
 		"lint:editorconfig:fix": "@lint:editorconfig --fix",
 		"lint:php": "@lint:php:fix --dry-run",


### PR DESCRIPTION
Since `composer.lock` is now part of the repository, we should check its integrity when running `composer normalize` (aka `composer lint`).