### PR TITLE
[TASK] Switch to `ncipollo/release-action` for new releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -141,10 +141,7 @@ jobs:
 
       # Create release
       - name: Create release
-        id: create-release
-        uses: softprops/action-gh-release@v1
+        uses: ncipollo/release-action@v1
         with:
-          generate_release_notes: true
-          files: |
-            .build/cache-warmup.phar
-            .build/cache-warmup.phar.asc
+          generateReleaseNotes: true
+          artifacts: .build/cache-warmup.phar,.build/cache-warmup.phar.asc


### PR DESCRIPTION
The previously used action `softprops/action-gh-release` was not properly updated anymore. Thus, we now switch to the actively maintained action `ncipollo/release-action`.