### PR TITLE
[BUGFIX] Follow redirects when parsing XML sitemap

### DIFF
--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -30,6 +30,7 @@ use EliasHaeussler\CacheWarmup\Normalizer;
 use EliasHaeussler\CacheWarmup\Result;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use GuzzleHttp\Client as GuzzleClient;
+use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Psr7;
 use Psr\Http\Client;
 use Symfony\Component\PropertyInfo;
@@ -56,7 +57,12 @@ final class XmlParser
     {
         // Fetch XML source
         $request = new Psr7\Request('GET', $sitemap->getUri());
-        $response = $this->client->sendRequest($request);
+        if ($this->client instanceof ClientInterface) {
+            // Make sure redirects and errors are properly handled when using a Guzzle client
+            $response = $this->client->send($request);
+        } else {
+            $response = $this->client->sendRequest($request);
+        }
         $body = (string) $response->getBody();
 
         // Deserialize XML

--- a/tests/Unit/ClientMockTrait.php
+++ b/tests/Unit/ClientMockTrait.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Unit;
 
 use GuzzleHttp\Handler;
+use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use Psr\Http\Client;
 
@@ -58,7 +59,7 @@ trait ClientMockTrait
     {
         $this->mockHandler = new Handler\MockHandler();
 
-        return new \GuzzleHttp\Client(['handler' => $this->mockHandler]);
+        return new \GuzzleHttp\Client(['handler' => HandlerStack::create($this->mockHandler)]);
     }
 
     protected function openStream(string $file): Psr7\Stream

--- a/tests/Unit/Fixtures/DummyClient.php
+++ b/tests/Unit/Fixtures/DummyClient.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Fixtures;
+
+use GuzzleHttp\Psr7;
+use Psr\Http\Client;
+use Psr\Http\Message;
+
+/**
+ * DummyClient.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class DummyClient implements Client\ClientInterface
+{
+    public ?Message\ResponseInterface $expectedResponse = null;
+
+    public function sendRequest(Message\RequestInterface $request): Message\ResponseInterface
+    {
+        return $this->expectedResponse ?? new Psr7\Response();
+    }
+}


### PR DESCRIPTION
When using a Guzzle client for XML sitemap parsing, redirects were not followed prior to this PR. This is because the client disables the `allow_redirects` option in case the PSR-18 compatible `$client->sendRequest()` method is used:

https://github.com/guzzle/guzzle/blob/b50a2a1251152e43f6a37f0fa053e730a67d25ba/src/Client.php#L134

We now use the `$client->send()` method instead in case a Guzzle client is configured.

Resolves: eliashaeussler/typo3-warming#182