### PR TITLE
[BUGFIX] Explicitly disable `latest` Docker tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,9 +81,10 @@ jobs:
         with:
           images: eliashaeussler/cache-warmup
           tags: |
-            type=raw,value=latest,enable=false
             type=semver,pattern={{version}}
             type=raw,value=${{ github.ref_name }},enable=${{ github.event_name == 'workflow_dispatch' }}
+          flavor:
+            latest=false
 
       # Prepare build
       - name: Set up QEMU


### PR DESCRIPTION
This is a follow-up of #105.