### PR TITLE
[!!!][FEATURE] Introduce response handlers

### DIFF
--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler;
+
+use EliasHaeussler\CacheWarmup\Http;
+use Generator;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Pool;
+use GuzzleHttp\Psr7;
+use Psr\Http\Message;
+
+use function array_values;
+
+/**
+ * ConcurrentCrawlerTrait.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+trait ConcurrentCrawlerTrait
+{
+    /**
+     * @param list<Message\UriInterface>                          $urls
+     * @param list<Http\Message\Handler\ResponseHandlerInterface> $handlers
+     */
+    protected function createPool(
+        array $urls,
+        ClientInterface $client,
+        array $handlers = [],
+    ): Pool {
+        return Http\Message\RequestPoolFactory::create($this->buildRequests($urls))
+            ->withClient($client)
+            ->withConcurrency($this->options['concurrency'])
+            ->withOptions($this->options['request_options'])
+            ->withResponseHandler(...array_values($handlers))
+            ->createPool()
+        ;
+    }
+
+    /**
+     * @param list<Message\UriInterface> $urls
+     *
+     * @return Generator<int, Message\RequestInterface>
+     */
+    protected function buildRequests(array $urls): Generator
+    {
+        foreach ($urls as $url) {
+            yield new Psr7\Request(
+                $this->options['request_method'],
+                $url,
+                $this->options['request_headers'],
+            );
+        }
+    }
+}

--- a/src/Crawler/VerboseCrawlerInterface.php
+++ b/src/Crawler/VerboseCrawlerInterface.php
@@ -33,5 +33,5 @@ use Symfony\Component\Console;
  */
 interface VerboseCrawlerInterface extends CrawlerInterface
 {
-    public function setOutput(Console\Output\OutputInterface $output): self;
+    public function setOutput(Console\Output\OutputInterface $output): void;
 }

--- a/src/Http/Message/Handler/OutputtingProgressHandler.php
+++ b/src/Http/Message/Handler/OutputtingProgressHandler.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Http\Message\Handler;
+
+use Psr\Http\Message;
+use Symfony\Component\Console;
+use Throwable;
+
+/**
+ * OutputtingProgressHandler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class OutputtingProgressHandler implements ResponseHandlerInterface
+{
+    private const PROGRESS_BAR_FORMAT = ' %current%/%max% [%bar%] %percent:3s%% -- %url% %state%';
+
+    private Console\Helper\ProgressBar $progressBar;
+
+    public function __construct(
+        Console\Output\OutputInterface $output,
+        int $max,
+    ) {
+        $this->progressBar = $this->createProgressBar($output, $max);
+    }
+
+    public function startProgressBar(): void
+    {
+        $this->progressBar->setMessage('', 'url');
+        $this->progressBar->setMessage('', 'state');
+        $this->progressBar->start();
+    }
+
+    public function finishProgressBar(): void
+    {
+        $this->progressBar->finish();
+    }
+
+    public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void
+    {
+        $this->progressBar->setMessage((string) $uri, 'url');
+        $this->progressBar->setMessage('(<info>success</info>)', 'state');
+        $this->progressBar->advance();
+        $this->progressBar->display();
+    }
+
+    public function onFailure(Throwable $exception, Message\UriInterface $uri): void
+    {
+        $this->progressBar->setMessage((string) $uri, 'url');
+        $this->progressBar->setMessage('(<error>failed</error>)', 'state');
+        $this->progressBar->advance();
+        $this->progressBar->display();
+    }
+
+    private function createProgressBar(Console\Output\OutputInterface $output, int $max): Console\Helper\ProgressBar
+    {
+        Console\Helper\ProgressBar::setFormatDefinition('cache-warmup', self::PROGRESS_BAR_FORMAT);
+
+        $progressBar = new Console\Helper\ProgressBar($output, $max);
+
+        $progressBar->setFormat('cache-warmup');
+        $progressBar->setOverwrite(false);
+
+        return $progressBar;
+    }
+}

--- a/src/Http/Message/Handler/ResponseHandlerInterface.php
+++ b/src/Http/Message/Handler/ResponseHandlerInterface.php
@@ -21,21 +21,20 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Exception;
+namespace EliasHaeussler\CacheWarmup\Http\Message\Handler;
+
+use Psr\Http\Message;
+use Throwable;
 
 /**
- * MissingArgumentException.
+ * ResponseHandlerInterface.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class MissingArgumentException extends Exception
+interface ResponseHandlerInterface
 {
-    public static function create(string $argumentName): self
-    {
-        return new self(
-            sprintf('Required argument "$%s" is missing.', ltrim($argumentName, '$')),
-            1619635638
-        );
-    }
+    public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void;
+
+    public function onFailure(Throwable $exception, Message\UriInterface $uri): void;
 }

--- a/src/Http/Message/Handler/ResultCollectorHandler.php
+++ b/src/Http/Message/Handler/ResultCollectorHandler.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Http\Message\Handler;
+
+use EliasHaeussler\CacheWarmup\Result;
+use Psr\Http\Message;
+use Throwable;
+
+/**
+ * ResultCollectorHandler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ResultCollectorHandler implements ResponseHandlerInterface
+{
+    private Result\CacheWarmupResult $result;
+
+    public function __construct()
+    {
+        $this->result = new Result\CacheWarmupResult();
+    }
+
+    public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void
+    {
+        $this->result->addResult(
+            Result\CrawlingResult::createSuccessful($uri, [
+                'response' => $response,
+            ]),
+        );
+    }
+
+    public function onFailure(Throwable $exception, Message\UriInterface $uri): void
+    {
+        $this->result->addResult(
+            Result\CrawlingResult::createFailed($uri, [
+                'exception' => $exception,
+            ]),
+        );
+    }
+
+    public function getResult(): Result\CacheWarmupResult
+    {
+        return $this->result;
+    }
+}

--- a/src/Http/Message/RequestPoolFactory.php
+++ b/src/Http/Message/RequestPoolFactory.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Http\Message;
+
+use Generator;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Pool;
+use Psr\Http\Message;
+use Throwable;
+
+use function array_values;
+
+/**
+ * RequestPoolFactory.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequestPoolFactory
+{
+    private ClientInterface $client;
+    private int $concurrency = 5;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $options = [];
+
+    /**
+     * @var list<Handler\ResponseHandlerInterface>
+     */
+    private array $handlers = [];
+
+    /**
+     * @var array<int, Message\RequestInterface>
+     */
+    private array $visited = [];
+
+    /**
+     * @param iterable<int, Message\RequestInterface> $requests
+     */
+    private function __construct(
+        private readonly iterable $requests,
+    ) {
+        $this->client = new Client();
+    }
+
+    /**
+     * @param iterable<int, Message\RequestInterface> $requests
+     */
+    public static function create(iterable $requests): self
+    {
+        return new self($requests);
+    }
+
+    public function createPool(): Pool
+    {
+        return new Pool(
+            $this->client,
+            $this->decorateRequests(),
+            [
+                'concurrency' => $this->concurrency,
+                'options' => $this->options,
+                'fulfilled' => $this->onFulfilled(...),
+                'rejected' => $this->onRejected(...),
+            ],
+        );
+    }
+
+    private function onFulfilled(Message\ResponseInterface $response, int $index): void
+    {
+        foreach ($this->handlers as $handler) {
+            $handler->onSuccess($response, $this->visited[$index]->getUri());
+        }
+    }
+
+    private function onRejected(Throwable $throwable, int $index): void
+    {
+        foreach ($this->handlers as $handler) {
+            $handler->onFailure($throwable, $this->visited[$index]->getUri());
+        }
+    }
+
+    /**
+     * @return Generator<Message\RequestInterface>
+     */
+    private function decorateRequests(): Generator
+    {
+        foreach ($this->requests as $index => $request) {
+            yield $this->visited[$index] = $request;
+        }
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function withClient(ClientInterface $client): self
+    {
+        $clone = clone $this;
+        $clone->client = $client;
+
+        return $clone;
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function withConcurrency(int $concurrency): self
+    {
+        $clone = clone $this;
+        $clone->concurrency = $concurrency;
+
+        return $clone;
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     *
+     * @phpstan-impure
+     */
+    public function withOptions(array $options): self
+    {
+        $clone = clone $this;
+        $clone->options = $options;
+
+        return $clone;
+    }
+
+    /**
+     * @phpstan-impure
+     */
+    public function withResponseHandler(Handler\ResponseHandlerInterface ...$handler): self
+    {
+        $clone = clone $this;
+        $clone->handlers = [...$clone->handlers, ...array_values($handler)];
+
+        return $clone;
+    }
+}

--- a/tests/Unit/Crawler/DummyVerboseCrawler.php
+++ b/tests/Unit/Crawler/DummyVerboseCrawler.php
@@ -38,10 +38,8 @@ final class DummyVerboseCrawler extends DummyCrawler implements Crawler\VerboseC
 {
     public static ?Console\Output\OutputInterface $output = null;
 
-    public function setOutput(Console\Output\OutputInterface $output): Crawler\VerboseCrawlerInterface
+    public function setOutput(Console\Output\OutputInterface $output): void
     {
         self::$output = $output;
-
-        return $this;
     }
 }

--- a/tests/Unit/Http/Message/Handler/OutputtingProgressHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/OutputtingProgressHandlerTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Http\Message\Handler;
+
+use EliasHaeussler\CacheWarmup\Http;
+use Exception;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * OutputtingProgressHandlerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class OutputtingProgressHandlerTest extends Framework\TestCase
+{
+    private Console\Output\BufferedOutput $output;
+    private Http\Message\Handler\OutputtingProgressHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = new Http\Message\Handler\OutputtingProgressHandler($this->output, 10);
+    }
+
+    /**
+     * @test
+     */
+    public function startProgressBarStartsProgressBar(): void
+    {
+        $this->subject->startProgressBar();
+
+        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0% -- {2}$#m', $this->output->fetch());
+    }
+
+    /**
+     * @test
+     */
+    public function finishProgressBarFinishesProgressBar(): void
+    {
+        $this->subject->startProgressBar();
+        $this->subject->finishProgressBar();
+
+        $output = $this->output->fetch();
+
+        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0% -- {2}$#m', $output);
+        self::assertMatchesRegularExpression('#^\s*10/10 \S+\s+100% -- {2}$#m', $output);
+    }
+
+    /**
+     * @test
+     */
+    public function onSuccessPrintsSuccessfulUrlAndAdvancesProgressBarByOneStep(): void
+    {
+        $response = new Psr7\Response();
+        $uri = new Psr7\Uri('https://www.example.com');
+
+        $this->subject->startProgressBar();
+        $this->subject->onSuccess($response, $uri);
+
+        self::assertMatchesRegularExpression(
+            sprintf('#^\s*1/10 [^\s]+\s+10%% -- %s \(success\)$#m', preg_quote((string) $uri)),
+            $this->output->fetch(),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function onFailurePrintsFailedUrlAndAdvancesProgressBarByOneStep(): void
+    {
+        $exception = new Exception('foo');
+        $uri = new Psr7\Uri('https://www.example.com');
+
+        $this->subject->startProgressBar();
+        $this->subject->onFailure($exception, $uri);
+
+        self::assertMatchesRegularExpression(
+            sprintf('#^\s*1/10 [^\s]+\s+10%% -- %s \(failed\)$#m', preg_quote((string) $uri)),
+            $this->output->fetch(),
+        );
+    }
+}

--- a/tests/Unit/Http/Message/Handler/ResultCollectorHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/ResultCollectorHandlerTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Http\Message\Handler;
+
+use EliasHaeussler\CacheWarmup\Http;
+use EliasHaeussler\CacheWarmup\Result;
+use Exception;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+
+/**
+ * ResultCollectorHandlerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ResultCollectorHandlerTest extends Framework\TestCase
+{
+    private Http\Message\Handler\ResultCollectorHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Http\Message\Handler\ResultCollectorHandler();
+    }
+
+    /**
+     * @test
+     */
+    public function onSuccessAddsSuccessfulCrawlingResult(): void
+    {
+        $response = new Psr7\Response();
+        $uri = new Psr7\Uri('https://www.example.com');
+
+        $expected = Result\CrawlingResult::createSuccessful($uri, ['response' => $response]);
+
+        self::assertSame([], $this->subject->getResult()->getSuccessful());
+        self::assertSame([], $this->subject->getResult()->getFailed());
+
+        $this->subject->onSuccess($response, $uri);
+
+        self::assertEquals([$expected], $this->subject->getResult()->getSuccessful());
+        self::assertSame([], $this->subject->getResult()->getFailed());
+    }
+
+    /**
+     * @test
+     */
+    public function onFailureAddsFailedCrawlingResult(): void
+    {
+        $exception = new Exception('foo');
+        $uri = new Psr7\Uri('https://www.example.com');
+
+        $expected = Result\CrawlingResult::createFailed($uri, ['exception' => $exception]);
+
+        self::assertSame([], $this->subject->getResult()->getSuccessful());
+        self::assertSame([], $this->subject->getResult()->getFailed());
+
+        $this->subject->onFailure($exception, $uri);
+
+        self::assertSame([], $this->subject->getResult()->getSuccessful());
+        self::assertEquals([$expected], $this->subject->getResult()->getFailed());
+    }
+}

--- a/tests/Unit/Http/Message/RequestPoolFactoryTest.php
+++ b/tests/Unit/Http/Message/RequestPoolFactoryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Http\Message;
+
+use EliasHaeussler\CacheWarmup\Http;
+use EliasHaeussler\CacheWarmup\Tests;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+use Psr\Http\Message;
+
+use function sort;
+
+/**
+ * RequestPoolFactoryTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class RequestPoolFactoryTest extends Framework\TestCase
+{
+    use Tests\Unit\ClientMockTrait;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createClient();
+    }
+
+    /**
+     * @test
+     */
+    public function createReturnsObjectForGivenRequests(): void
+    {
+        $visitedUrls = [];
+        $response = function (Message\RequestInterface $request) use (&$visitedUrls) {
+            $visitedUrls[] = (string) $request->getUri();
+
+            return new Psr7\Response();
+        };
+
+        $expected = [
+            'https://www.example.com/',
+            'https://www.example.com/baz',
+            'https://www.example.com/foo',
+        ];
+
+        $actual = Http\Message\RequestPoolFactory::create([
+            new Psr7\Request('GET', 'https://www.example.com/'),
+            new Psr7\Request('GET', 'https://www.example.com/foo'),
+            new Psr7\Request('GET', 'https://www.example.com/baz'),
+        ])->withClient($this->client);
+
+        $this->mockHandler->append(
+            $response(...),
+            $response(...),
+            $response(...),
+        );
+
+        $actual->createPool()->promise()->wait();
+
+        sort($visitedUrls);
+
+        self::assertSame($expected, $visitedUrls);
+    }
+
+    /**
+     * @test
+     */
+    public function forEachReturnsObjectForEachGivenRequest(): void
+    {
+        $visitedUrls = [];
+        $response = function (Message\RequestInterface $request) use (&$visitedUrls) {
+            $visitedUrls[] = (string) $request->getUri();
+
+            return new Psr7\Response();
+        };
+
+        $expected = [
+            'https://www.example.com/',
+            'https://www.example.com/baz',
+            'https://www.example.com/foo',
+        ];
+
+        $actual = Http\Message\RequestPoolFactory::create([
+            new Psr7\Request('GET', 'https://www.example.com/'),
+            new Psr7\Request('GET', 'https://www.example.com/foo'),
+            new Psr7\Request('GET', 'https://www.example.com/baz'),
+        ])->withClient($this->client);
+
+        $this->mockHandler->append(
+            $response(...),
+            $response(...),
+            $response(...),
+        );
+
+        $actual->createPool()->promise()->wait();
+
+        sort($visitedUrls);
+
+        self::assertSame($expected, $visitedUrls);
+    }
+}


### PR DESCRIPTION
This PR introduces response handlers. Response handlers are used to perform specific actions for several responses of cache warmup request. Currently, only two response handlers are available:

- `Http\Message\Handler\OutputtingProgressHandler` creates a progress bar and updates it on each handled response. This is mainly an extraction of the internal handling of `Crawler\OutputtingCrawler`.
- `Http\Message\Handler\ResultCollectorHandler` creates a new `Result\CacheWarmupResult` and adds each handled response as `Result\CrawlingResult` to it. This is mainly an extraction of the internal handling of `Crawler\ConcurrentCrawler`.

In addition, the concurrent request handling part of both default crawlers is extracted to a new `Http\Message\RequestPoolFactory` component. The request pool also accepts a set of request options to be passed to each cache warmup request. For this, a new configuration option `request_options` is added to both default crawlers.

Since request and response handling parts of both default crawlers are now available as separate components, the crawlers have been marked as `final`.