### PR TITLE
[FEATURE] Introduce compact and verbose progress handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@
 [![Docker](https://img.shields.io/docker/v/eliashaeussler/cache-warmup?label=docker&sort=semver)](https://hub.docker.com/r/eliashaeussler/cache-warmup)
 [![License](http://poser.pugx.org/eliashaeussler/cache-warmup/license)](LICENSE)
 
-:package:&nbsp;[Packagist](https://packagist.org/packages/eliashaeussler/cache-warmup) |
-:floppy_disk:&nbsp;[Repository](https://github.com/eliashaeussler/cache-warmup) |
-:bug:&nbsp;[Issue tracker](https://github.com/eliashaeussler/cache-warmup/issues)
+📦&nbsp;[Packagist](https://packagist.org/packages/eliashaeussler/cache-warmup) |
+💾&nbsp;[Repository](https://github.com/eliashaeussler/cache-warmup) |
+🐛&nbsp;[Issue tracker](https://github.com/eliashaeussler/cache-warmup/issues)
 
 </div>
 
@@ -26,7 +26,7 @@ is performed by concurrently sending a simple `HEAD` request to those pages,
 either from the command-line or by using the provided PHP API. It is even
 possible to write custom crawlers that take care of cache warmup.
 
-## :rocket: Features
+## 🚀 Features
 
 * Warmup caches of pages located in XML sitemaps
 * Optionally warmup caches of single pages
@@ -34,7 +34,7 @@ possible to write custom crawlers that take care of cache warmup.
 * Additional Docker image
 * Interface for custom crawler implementations
 
-## :fire: Installation
+## 🔥 Installation
 
 ### Composer
 
@@ -59,59 +59,30 @@ phive install eliashaeussler/cache-warmup
 
 Please have a look at [`Usage with Docker`](#usage-with-docker).
 
-## :zap: Usage
+## ⚡ Usage
 
 ### Command-line usage
 
-**General usage**
-
-```
-./vendor/bin/cache-warmup \
-  [-u|--urls=URLS...] \
-  [-l|--limit=LIMIT] \
-  [-p|--progress|--no-progress] \
-  [-c|--crawler=CRAWLER] \
-  [-o|--crawler-options=CRAWLER-OPTIONS] \
-  [--allow-failures] \
-  [<sitemaps>...]
-```
-
-:bulb: Run `./vendor/bin/cache-warmup --help` to see all available input
-options and arguments.
-
-**Extended usage**
-
 ```bash
-# Warm up caches of specific sitemap
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml"
-
-# Limit number of pages to be crawled
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --limit 50
-
-# Show or hide progress bar (progress bar is shown by default with increased verbosity)
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --[no-]progress
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --verbose
-
-# Use custom crawler (must implement EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface)
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --crawler "Vendor\Crawler\MyCrawler"
-
-# Provide crawler options (only used for configurable crawlers)
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --crawler-options '{"concurrency": 3}'
-
-# Exit gracefully even if crawling of URLs failed
-./vendor/bin/cache-warmup "https://www.example.org/sitemap.xml" --allow-failures
-
-# Define URLs to be crawled
-./vendor/bin/cache-warmup -u "https://www.example.org/" \
-    -u "https://www.example.org/foo" \
-    -u "https://www.example.org/baz"
+vendor/bin/cache-warmup [options] [<sitemaps>...]
 ```
 
-For more detailed information run `./vendor/bin/cache-warmup --help`.
+The following input parameters are available:
+
+| Parameter                 | Description                                                                                                                                             |
+|---------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `sitemaps`                | URLs of XML sitemaps to be warmed up *(multiple values allowed)*                                                                                        |
+| `--urls`, `-u`            | Additional URLs to be warmed up *(multiple values allowed)*                                                                                             |
+| `--limit`, `-l`           | Limit the number of URLs to be processed *(default: 0)*                                                                                                 |
+| `--progress`, `-p`        | Show progress bar during cache warmup                                                                                                                   |
+| `--crawler`, `-c`         | FQCN of the crawler to use for cache warming (must implement [`EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface`](src/Crawler/CrawlerInterface.php)) |
+| `--crawler-options`, `-o` | JSON-encoded string of additional config for configurable crawlers                                                                                      |
+| `--allow-failures`        | Allow failures during URL crawling and exit with zero                                                                                                   |
+
+💡 Run `vendor/bin/cache-warmup --help` to see a detailed explanation of
+all available input parameters.
 
 ### Code usage
-
-**General usage**
 
 ```php
 // Instantiate and run cache warmer
@@ -124,81 +95,20 @@ $successfulUrls = $result->getSuccessful();
 $failedUrls = $result->getFailed();
 ```
 
-**Extended usage**
-
-```php
-// Limit number of pages to be crawled
-$limit = 50;
-
-// Use custom client
-$client = new \GuzzleHttp\Client([
-    // ...
-]);
-
-// Use custom crawler (must implement EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface)
-$crawler = new \Vendor\Crawler\MyCrawler();
-$crawler->setOptions(['concurrency' => 3]);
-
-// Enable strict mode (throws exception if XML parsing fails)
-$strict = true;
-
-// Instantiate cache warmer
-$cacheWarmer = new \EliasHaeussler\CacheWarmup\CacheWarmer($limit, $client, $crawler, $strict);
-
-// Define sitemaps to be crawled
-$cacheWarmer->addSitemaps('https://www.example.org/sitemap.xml');
-$cacheWarmer->addSitemaps('https://www.example.org/de/sitemap.xml');
-
-// Define URLs to be crawled
-$cacheWarmer->addUrl('https://www.example.org/');
-$cacheWarmer->addUrl('https://www.example.org/foo');
-$cacheWarmer->addUrl('https://www.example.org/baz');
-
-// Run cache warmer
-$result = $cacheWarmer->run();
-
-// Get successful and failed URLs
-$successfulUrls = $result->getSuccessful();
-$failedUrls = $result->getFailed();
-```
-
 ### Usage with Docker
 
-**General usage**
-
 ```bash
-docker run --rm -it eliashaeussler/cache-warmup <options>
+docker run --rm -it eliashaeussler/cache-warmup [options] [<sitemaps>...]
 ```
 
-**Extended usage**
-
-```bash
-# Use latest version
-docker run --rm -it eliashaeussler/cache-warmup:latest <options>
-
-# Use specific version
-docker run --rm -it eliashaeussler/cache-warmup:0.3.0 <options>
-```
-
-**Usage with docker-compose**
-
-```yaml
-version: '3.6'
-
-services:
-  cache-warmup:
-    image: eliashaeussler/cache-warmup
-    command: [<options>]
-```
-
-## :technologist: Contributing
+## 🧑‍💻 Contributing
 
 Please have a look at [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-## :gem: Credits
+## 💎 Credits
 
 [Background vector created by photoroyalty - www.freepik.com](https://www.freepik.com/vectors/background)
 
-## :star: License
+## ⭐ License
 
 This project is licensed under [GNU General Public License 3.0 (or later)](LICENSE).

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -84,6 +84,17 @@ final class CacheWarmupCommand extends Console\Command\Command
             '',
             '   <comment>%command.full_name% -u https://www.example.com/foo -u https://www.example.com/baz</comment>',
             '',
+            '<info>Progress bar</info>',
+            '<info>============</info>',
+            'You can track the cache warmup progress by using the <comment>--progress</comment> option:',
+            '',
+            '   <comment>%command.full_name% --progress</comment>',
+            '',
+            'This shows a compact progress bar, including current warmup failures.',
+            'For a more verbose output, add the <comment>--verbose</comment> option:',
+            '',
+            '   <comment>%command.full_name% --progress --verbose</comment>',
+            '',
             '<info>URL limit</info>',
             '<info>=========</info>',
             'The number of URLs to be crawled can be limited using the <comment>--limit</comment> option:',
@@ -139,7 +150,7 @@ final class CacheWarmupCommand extends Console\Command\Command
         $this->addOption(
             'progress',
             'p',
-            Console\Input\InputOption::VALUE_NEGATABLE,
+            Console\Input\InputOption::VALUE_NONE,
             'Show progress bar during cache warmup'
         );
         $this->addOption(
@@ -269,6 +280,8 @@ final class CacheWarmupCommand extends Console\Command\Command
                 $this->io->section('The following URLs were successfully crawled:');
                 $this->io->listing($this->decorateCrawledUrls($successfulUrls));
             }
+        }
+        if ($this->io->isVerbose()) {
             if ([] !== $failedUrls) {
                 $this->io->section('The following URLs failed during crawling:');
                 $this->io->listing($this->decorateCrawledUrls($failedUrls));
@@ -318,7 +331,7 @@ final class CacheWarmupCommand extends Console\Command\Command
 
             /** @var Crawler\CrawlerInterface $crawler */
             $crawler = new $crawler();
-        } elseif ($this->isProgressBarEnabled($output, $input)) {
+        } elseif ($input->getOption('progress')) {
             // Use default verbose crawler
             $crawler = new Crawler\OutputtingCrawler();
         } else {
@@ -344,17 +357,6 @@ final class CacheWarmupCommand extends Console\Command\Command
         }
 
         return $crawler;
-    }
-
-    private function isProgressBarEnabled(
-        Console\Output\OutputInterface $output,
-        Console\Input\InputInterface $input,
-    ): bool {
-        if (false === $input->getOption('progress')) {
-            return false;
-        }
-
-        return $output->isVerbose() || true === $input->getOption('progress');
     }
 
     /**

--- a/src/Http/Message/Handler/CompactProgressHandler.php
+++ b/src/Http/Message/Handler/CompactProgressHandler.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Http\Message\Handler;
+
+use Psr\Http\Message;
+use Symfony\Component\Console;
+use Throwable;
+
+/**
+ * CompactProgressHandler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CompactProgressHandler implements ResponseHandlerInterface
+{
+    private const PROGRESS_BAR_FORMAT = ' %current%/%max% [%bar%] %percent:3s%% -- <%fail_tag%>%fail_count% %failures%</>';
+
+    private readonly Console\Helper\ProgressBar $progressBar;
+    private int $failures = 0;
+
+    public function __construct(
+        private readonly Console\Output\OutputInterface $output,
+        int $max,
+    ) {
+        $this->progressBar = $this->createProgressBar($output, $max);
+    }
+
+    public function startProgressBar(): void
+    {
+        $this->progressBar->setMessage('info', 'fail_tag');
+        $this->progressBar->setMessage('no', 'fail_count');
+        $this->progressBar->setMessage('failures', 'failures');
+        $this->progressBar->start();
+    }
+
+    public function finishProgressBar(): void
+    {
+        $this->progressBar->finish();
+        $this->output->writeln('');
+    }
+
+    public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void
+    {
+        $this->progressBar->advance();
+        $this->progressBar->display();
+    }
+
+    public function onFailure(Throwable $exception, Message\UriInterface $uri): void
+    {
+        $this->progressBar->setMessage((string) ++$this->failures, 'fail_count');
+
+        if ($this->failures > 0) {
+            $this->progressBar->setMessage('error', 'fail_tag');
+        }
+        if (1 === $this->failures) {
+            $this->progressBar->setMessage('failure', 'failures');
+        }
+        if (2 === $this->failures) {
+            $this->progressBar->setMessage('failures', 'failures');
+        }
+
+        $this->progressBar->advance();
+        $this->progressBar->display();
+    }
+
+    private function createProgressBar(Console\Output\OutputInterface $output, int $max): Console\Helper\ProgressBar
+    {
+        Console\Helper\ProgressBar::setFormatDefinition('cache-warmup', self::PROGRESS_BAR_FORMAT);
+
+        $progressBar = new Console\Helper\ProgressBar($output, $max);
+        $progressBar->setFormat('cache-warmup');
+
+        return $progressBar;
+    }
+}

--- a/tests/Unit/BufferedConsoleOutput.php
+++ b/tests/Unit/BufferedConsoleOutput.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit;
+
+use RuntimeException;
+use Symfony\Component\Console;
+
+use function fopen;
+use function fseek;
+use function is_string;
+use function stream_get_contents;
+
+/**
+ * BufferedConsoleOutput.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class BufferedConsoleOutput extends Console\Output\StreamOutput implements Console\Output\ConsoleOutputInterface
+{
+    /**
+     * @var resource
+     */
+    private $stream;
+    private Console\Output\OutputInterface $stderr;
+
+    public function __construct()
+    {
+        $this->stream = $this->createStream();
+        $this->stderr = new Console\Output\StreamOutput($this->createStream());
+
+        parent::__construct($this->stream, decorated: false);
+    }
+
+    public function getStream()
+    {
+        return $this->stream;
+    }
+
+    public function fetch(): string
+    {
+        fseek($this->stream, 0);
+
+        $output = stream_get_contents($this->stream);
+
+        if (!is_string($output)) {
+            throw new RuntimeException('The output stream cannot be processed.', 1676746403);
+        }
+
+        return $output;
+    }
+
+    public function getErrorOutput(): Console\Output\OutputInterface
+    {
+        return $this->stderr;
+    }
+
+    public function setErrorOutput(Console\Output\OutputInterface $error): void
+    {
+        $this->stderr = $error;
+    }
+
+    public function section(): Console\Output\ConsoleSectionOutput
+    {
+        $sections = [];
+
+        return new Console\Output\ConsoleSectionOutput(
+            $this->stream,
+            $sections,
+            $this->getVerbosity(),
+            $this->isDecorated(),
+            $this->getFormatter(),
+        );
+    }
+
+    /**
+     * @return resource
+     */
+    private function createStream()
+    {
+        $stream = fopen('php://temp', 'w+');
+
+        if (false === $stream) {
+            throw new RuntimeException('No output stream is available.', 1676746492);
+        }
+
+        return $stream;
+    }
+}

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -165,27 +165,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function executeHidesVerboseOutputIfVerbosityIsNormal(): void
-    {
-        $this->mockSitemapRequest('valid_sitemap_3');
-
-        $this->commandTester->execute([
-            'sitemaps' => [
-                'https://www.example.com/sitemap.xml',
-            ],
-        ]);
-
-        $output = $this->commandTester->getDisplay();
-
-        self::assertStringContainsString('Parsing sitemaps... Done', $output);
-        self::assertStringContainsString('Crawling URLs... Done', $output);
-        self::assertStringNotContainsString('* https://www.example.com/sitemap.xml', $output);
-        self::assertStringNotContainsString('* https://www.example.com/', $output);
-        self::assertStringNotContainsString('* https://www.example.com/foo', $output);
-    }
-
-    #[Framework\Attributes\Test]
-    public function executeHidesVerboseOutputIfNoProgressOptionIsSet(): void
+    public function executeDoesNotShowProgressBarIfProgressOptionIsNotSet(): void
     {
         $this->mockSitemapRequest('valid_sitemap_3');
 
@@ -194,7 +174,6 @@ final class CacheWarmupCommandTest extends Framework\TestCase
                 'sitemaps' => [
                     'https://www.example.com/sitemap.xml',
                 ],
-                '--no-progress' => true,
             ],
             [
                 'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERBOSE,
@@ -207,7 +186,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function executeShowsVerboseOutputIfProgressOptionIsSet(): void
+    public function executeShowsCompactProgressBarIfProgressOptionIsSetAndOutputIsNormal(): void
     {
         $this->mockSitemapRequest('valid_sitemap_3');
 
@@ -220,6 +199,31 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         $output = $this->commandTester->getDisplay();
 
+        self::assertStringNotContainsString(' SUCCESS ', $output);
+        self::assertStringContainsString('100%', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeShowsVerboseProgressBarIfProgressOptionIsSetAndOutputIsVerbose(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute(
+            [
+                'sitemaps' => [
+                    'https://www.example.com/sitemap.xml',
+                ],
+                '--progress' => true,
+            ],
+            [
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERBOSE,
+                'capture_stderr_separately' => true,
+            ]
+        );
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertStringContainsString(' SUCCESS ', $output);
         self::assertStringContainsString('100%', $output);
     }
 

--- a/tests/Unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/Unit/Crawler/OutputtingCrawlerTest.php
@@ -164,13 +164,7 @@ final class OutputtingCrawlerTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertMatchesRegularExpression(
-            sprintf('#^\s*1/2 [^\s]+\s+\d+%% -- %s \(success\)$#m', preg_quote((string) $uri1)),
-            $output
-        );
-        self::assertMatchesRegularExpression(
-            sprintf('#^\s*2/2 [^\s]+\s+\d+%% -- %s \(failed\)$#m', preg_quote((string) $uri2)),
-            $output
-        );
+        self::assertMatchesRegularExpression('#^\s*1/2 \S+\s+\d+% -- no failures$#m', $output);
+        self::assertMatchesRegularExpression('#^\s*2/2 \S+\s+\d+% -- 1 failure$#m', $output);
     }
 }

--- a/tests/Unit/Http/Message/Handler/CompactProgressHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/CompactProgressHandlerTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Http\Message\Handler;
+
+use EliasHaeussler\CacheWarmup\Http;
+use Exception;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * CompactProgressHandlerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CompactProgressHandlerTest extends Framework\TestCase
+{
+    private Console\Output\BufferedOutput $output;
+    private Http\Message\Handler\CompactProgressHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = new Http\Message\Handler\CompactProgressHandler($this->output, 10);
+    }
+
+    #[Framework\Attributes\Test]
+    public function startProgressBarStartsProgressBar(): void
+    {
+        $this->subject->startProgressBar();
+
+        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0% -- no failures$#m', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function finishProgressBarFinishesProgressBar(): void
+    {
+        $this->subject->startProgressBar();
+        $this->subject->finishProgressBar();
+
+        $output = $this->output->fetch();
+
+        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0% -- no failures$#m', $output);
+        self::assertMatchesRegularExpression('#^\s*10/10 \S+\s+100% -- no failures$#m', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function onSuccessPrintsSuccessfulUrlAndAdvancesProgressBarByOneStep(): void
+    {
+        $response = new Psr7\Response();
+        $uri = new Psr7\Uri('https://www.example.com');
+
+        $this->subject->startProgressBar();
+        $this->subject->onSuccess($response, $uri);
+
+        self::assertMatchesRegularExpression('#^\s*1/10 \S+\s+10% -- no failures$#m', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function onFailurePrintsFailedUrlAndAdvancesProgressBarByOneStep(): void
+    {
+        $exception = new Exception('foo');
+        $uri = new Psr7\Uri('https://www.example.com');
+
+        $this->subject->startProgressBar();
+        $this->subject->onFailure($exception, $uri);
+        $this->subject->onFailure($exception, $uri);
+
+        $output = $this->output->fetch();
+
+        self::assertMatchesRegularExpression('#^\s*1/10 \S+\s+10% -- 1 failure$#m', $output);
+        self::assertMatchesRegularExpression('#^\s*2/10 \S+\s+20% -- 2 failures$#m', $output);
+    }
+}

--- a/tests/Unit/Http/Message/Handler/VerboseProgressHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/VerboseProgressHandlerTest.php
@@ -24,26 +24,26 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Unit\Http\Message\Handler;
 
 use EliasHaeussler\CacheWarmup\Http;
+use EliasHaeussler\CacheWarmup\Tests;
 use Exception;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
-use Symfony\Component\Console;
 
 /**
- * OutputtingProgressHandlerTest.
+ * VerboseProgressHandlerTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class OutputtingProgressHandlerTest extends Framework\TestCase
+final class VerboseProgressHandlerTest extends Framework\TestCase
 {
-    private Console\Output\BufferedOutput $output;
-    private Http\Message\Handler\OutputtingProgressHandler $subject;
+    private Tests\Unit\BufferedConsoleOutput $output;
+    private Http\Message\Handler\VerboseProgressHandler $subject;
 
     protected function setUp(): void
     {
-        $this->output = new Console\Output\BufferedOutput();
-        $this->subject = new Http\Message\Handler\OutputtingProgressHandler($this->output, 10);
+        $this->output = new Tests\Unit\BufferedConsoleOutput();
+        $this->subject = new Http\Message\Handler\VerboseProgressHandler($this->output, 10);
     }
 
     #[Framework\Attributes\Test]
@@ -51,7 +51,7 @@ final class OutputtingProgressHandlerTest extends Framework\TestCase
     {
         $this->subject->startProgressBar();
 
-        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0% -- {2}$#m', $this->output->fetch());
+        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0%$#m', $this->output->fetch());
     }
 
     #[Framework\Attributes\Test]
@@ -62,8 +62,7 @@ final class OutputtingProgressHandlerTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertMatchesRegularExpression('#^\s*0/10 \S+\s+0% -- {2}$#m', $output);
-        self::assertMatchesRegularExpression('#^\s*10/10 \S+\s+100% -- {2}$#m', $output);
+        self::assertMatchesRegularExpression('#^\s*10/10 \S+\s+100%$#m', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -75,10 +74,10 @@ final class OutputtingProgressHandlerTest extends Framework\TestCase
         $this->subject->startProgressBar();
         $this->subject->onSuccess($response, $uri);
 
-        self::assertMatchesRegularExpression(
-            sprintf('#^\s*1/10 [^\s]+\s+10%% -- %s \(success\)$#m', preg_quote((string) $uri)),
-            $this->output->fetch(),
-        );
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString(' SUCCESS  '.$uri, $output);
+        self::assertMatchesRegularExpression('#^\s*1/10 \S+\s+10%$#m', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -90,9 +89,9 @@ final class OutputtingProgressHandlerTest extends Framework\TestCase
         $this->subject->startProgressBar();
         $this->subject->onFailure($exception, $uri);
 
-        self::assertMatchesRegularExpression(
-            sprintf('#^\s*1/10 [^\s]+\s+10%% -- %s \(failed\)$#m', preg_quote((string) $uri)),
-            $this->output->fetch(),
-        );
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString(' FAILURE  '.$uri, $output);
+        self::assertMatchesRegularExpression('#^\s*1/10 \S+\s+10%$#m', $output);
     }
 }


### PR DESCRIPTION
This PR converts the existing `OutputtingProgressHandler` to the new `CompactProgressHandler`. In addition, this handler does no longer print the crawling states. Instead, only a single progress bar with the current number of failures is shown.

Additionally, a new `VerboseProgressHandler` is added. This handler prints all crawling states in a modern way, next to a floating progress bar.

This also changes the output behavior of the `OutputtingCrawler`: If the passed output is normal (= not verbose), the compact handler will be used. On verbose output, the verbose handler is used. As a consequence, the `cache-warmup` command does no longer print a progress bar by default on verbose output. Instead, it needs to be enabled explicitly by passing the `--progress` command option:

- `vendor/bin/cache-warmup <sitemap>` → no progress bar
- `vendor/bin/cache-warmup <sitemap> -v` → verbose output, but no progress bar
- `vendor/bin/cache-warmup <sitemap> -p` → compact progress bar
- `vendor/bin/cache-warmup <sitemap> -p -v` → verbose progress bar