### PR TITLE
[FEATURE] Introduce formatters

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
+use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\PHPUnit\Set\PHPUnitLevelSetList;
@@ -39,6 +40,7 @@ return static function (RectorConfig $rectorConfig): void {
         AnnotationToAttributeRector::class => [
             __DIR__.'/src',
         ],
+        JsonThrowOnErrorRector::class,
     ]);
 
     $rectorConfig->phpVersion(PhpVersion::PHP_81);

--- a/rector.php
+++ b/rector.php
@@ -23,8 +23,8 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Core\ValueObject\PhpVersion;
-use Rector\Php73\Rector\FuncCall\JsonThrowOnErrorRector;
 use Rector\Php74\Rector\LNumber\AddLiteralSeparatorToNumberRector;
+use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\PHPUnit\Set\PHPUnitLevelSetList;
 use Rector\Set\ValueObject\LevelSetList;
 
@@ -36,7 +36,9 @@ return static function (RectorConfig $rectorConfig): void {
 
     $rectorConfig->skip([
         AddLiteralSeparatorToNumberRector::class,
-        JsonThrowOnErrorRector::class,
+        AnnotationToAttributeRector::class => [
+            __DIR__.'/src',
+        ],
     ]);
 
     $rectorConfig->phpVersion(PhpVersion::PHP_81);

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -361,8 +361,11 @@ HELP);
                 $this->io->writeln(json_encode($crawlerOptions, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
                 $this->io->newLine();
             }
-        } elseif ($this->formatter->isVerbose() && null !== $crawlerOptions) {
-            $this->io->warning('You passed crawler options for a non-configurable crawler.');
+        } elseif (null !== $crawlerOptions) {
+            $this->formatter->logMessage(
+                'You passed crawler options for a non-configurable crawler.',
+                Formatter\MessageSeverity::Warning,
+            );
         }
 
         return $crawler;

--- a/src/Exception/UnsupportedFormatterException.php
+++ b/src/Exception/UnsupportedFormatterException.php
@@ -21,55 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
+namespace EliasHaeussler\CacheWarmup\Exception;
+
+use function sprintf;
 
 /**
- * CacheWarmupResult.
+ * UnsupportedFormatterException.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CacheWarmupResult
+final class UnsupportedFormatterException extends Exception
 {
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $successful = [];
-
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $failed = [];
-
-    public function addResult(CrawlingResult $result): self
+    public static function create(string $type): self
     {
-        if ($result->isSuccessful()) {
-            $this->successful[] = $result;
-        } elseif ($result->isFailed()) {
-            $this->failed[] = $result;
-        }
-
-        return $this;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getSuccessful(): array
-    {
-        return $this->successful;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getFailed(): array
-    {
-        return $this->failed;
-    }
-
-    public function isSuccessful(): bool
-    {
-        return [] === $this->failed;
+        return new self(
+            sprintf('The formatter "%s" is not supported.', $type),
+            1676814093,
+        );
     }
 }

--- a/src/Formatter/Formatter.php
+++ b/src/Formatter/Formatter.php
@@ -21,55 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
+namespace EliasHaeussler\CacheWarmup\Formatter;
+
+use EliasHaeussler\CacheWarmup\Result;
 
 /**
- * CacheWarmupResult.
+ * Formatter.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CacheWarmupResult
+interface Formatter
 {
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $successful = [];
+    public function formatParserResult(Result\ParserResult $successful, Result\ParserResult $failed): void;
 
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $failed = [];
+    public function formatCacheWarmupResult(Result\CacheWarmupResult $result): void;
 
-    public function addResult(CrawlingResult $result): self
-    {
-        if ($result->isSuccessful()) {
-            $this->successful[] = $result;
-        } elseif ($result->isFailed()) {
-            $this->failed[] = $result;
-        }
+    public function isVerbose(): bool;
 
-        return $this;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getSuccessful(): array
-    {
-        return $this->successful;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getFailed(): array
-    {
-        return $this->failed;
-    }
-
-    public function isSuccessful(): bool
-    {
-        return [] === $this->failed;
-    }
+    public static function getType(): string;
 }

--- a/src/Formatter/FormatterFactory.php
+++ b/src/Formatter/FormatterFactory.php
@@ -21,55 +21,33 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
+namespace EliasHaeussler\CacheWarmup\Formatter;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use Symfony\Component\Console;
 
 /**
- * CacheWarmupResult.
+ * FormatterFactory.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CacheWarmupResult
+final class FormatterFactory
 {
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $successful = [];
-
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $failed = [];
-
-    public function addResult(CrawlingResult $result): self
-    {
-        if ($result->isSuccessful()) {
-            $this->successful[] = $result;
-        } elseif ($result->isFailed()) {
-            $this->failed[] = $result;
-        }
-
-        return $this;
+    public function __construct(
+        private readonly Console\Style\SymfonyStyle $io,
+    ) {
     }
 
     /**
-     * @return list<CrawlingResult>
+     * @throws Exception\UnsupportedFormatterException
      */
-    public function getSuccessful(): array
+    public function get(string $type): Formatter
     {
-        return $this->successful;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getFailed(): array
-    {
-        return $this->failed;
-    }
-
-    public function isSuccessful(): bool
-    {
-        return [] === $this->failed;
+        return match ($type) {
+            JsonFormatter::getType() => new JsonFormatter($this->io),
+            TextFormatter::getType() => new TextFormatter($this->io),
+            default => throw Exception\UnsupportedFormatterException::create($type),
+        };
     }
 }

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -50,6 +50,7 @@ use function json_encode;
  *         success?: list<string>,
  *         failure?: list<string>,
  *     },
+ *     messages?: array<value-of<MessageSeverity>, list<string>>
  * }
  */
 final class JsonFormatter implements Formatter
@@ -97,6 +98,19 @@ final class JsonFormatter implements Formatter
         if ([] !== ($failedUrls = $result->getFailed())) {
             $this->json['cacheWarmupResult']['failure'] = array_map('strval', $failedUrls);
         }
+    }
+
+    public function logMessage(string $message, MessageSeverity $severity = MessageSeverity::Info): void
+    {
+        if (!is_array($this->json['messages'] ?? null)) {
+            $this->json['messages'] = [];
+        }
+
+        if (!is_array($this->json['messages'][$severity->value] ?? null)) {
+            $this->json['messages'][$severity->value] = [];
+        }
+
+        $this->json['messages'][$severity->value][] = $message;
     }
 
     public function isVerbose(): bool

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Formatter;
+
+use EliasHaeussler\CacheWarmup\Result;
+use Symfony\Component\Console;
+
+use function array_map;
+use function is_array;
+use function json_encode;
+
+/**
+ * JsonFormatter.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @phpstan-type JsonArray array{
+ *     parserResult?: array{
+ *         success?: array{
+ *             sitemaps: list<string>,
+ *             urls: list<string>,
+ *         },
+ *         failure?: array{
+ *             sitemaps: list<string>,
+ *         },
+ *     },
+ *     cacheWarmupResult?: array{
+ *         success?: list<string>,
+ *         failure?: list<string>,
+ *     },
+ * }
+ */
+final class JsonFormatter implements Formatter
+{
+    /**
+     * @phpstan-var JsonArray
+     */
+    private array $json = [];
+
+    public function __construct(
+        private readonly Console\Style\SymfonyStyle $io,
+    ) {
+    }
+
+    public function formatParserResult(Result\ParserResult $successful, Result\ParserResult $failed): void
+    {
+        if ($this->io->isVeryVerbose()) {
+            $this->json['parserResult'] = [
+                'success' => [
+                    'sitemaps' => array_map('strval', $successful->getSitemaps()),
+                    'urls' => array_map('strval', $successful->getUrls()),
+                ],
+            ];
+        }
+
+        if ([] !== ($failedSitemaps = $failed->getSitemaps())) {
+            if (!is_array($this->json['parserResult'] ?? null)) {
+                $this->json['parserResult'] = [];
+            }
+
+            $this->json['parserResult']['failure'] = [
+                'sitemaps' => array_map('strval', $failedSitemaps),
+            ];
+        }
+    }
+
+    public function formatCacheWarmupResult(Result\CacheWarmupResult $result): void
+    {
+        $this->json['cacheWarmupResult'] = [];
+
+        if ([] !== ($successfulUrls = $result->getSuccessful())) {
+            $this->json['cacheWarmupResult']['success'] = array_map('strval', $successfulUrls);
+        }
+
+        if ([] !== ($failedUrls = $result->getFailed())) {
+            $this->json['cacheWarmupResult']['failure'] = array_map('strval', $failedUrls);
+        }
+    }
+
+    public function isVerbose(): bool
+    {
+        return false;
+    }
+
+    /**
+     * @phpstan-return JsonArray
+     */
+    public function getJson(): array
+    {
+        return $this->json;
+    }
+
+    public static function getType(): string
+    {
+        return 'json';
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function __destruct()
+    {
+        // Early return if no JSON data was added
+        if ([] === $this->json) {
+            return;
+        }
+
+        // Early return if output is quiet
+        if ($this->io->isQuiet()) {
+            return;
+        }
+
+        $flags = JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR;
+
+        // Pretty-print JSON on verbose output
+        if ($this->io->isVerbose()) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+
+        $this->io->writeln(json_encode($this->json, $flags));
+    }
+}

--- a/src/Formatter/MessageSeverity.php
+++ b/src/Formatter/MessageSeverity.php
@@ -23,23 +23,16 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Formatter;
 
-use EliasHaeussler\CacheWarmup\Result;
-
 /**
- * Formatter.
+ * MessageSeverity.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface Formatter
+enum MessageSeverity: string
 {
-    public function formatParserResult(Result\ParserResult $successful, Result\ParserResult $failed): void;
-
-    public function formatCacheWarmupResult(Result\CacheWarmupResult $result): void;
-
-    public function logMessage(string $message, MessageSeverity $severity = MessageSeverity::Info): void;
-
-    public function isVerbose(): bool;
-
-    public static function getType(): string;
+    case Error = 'error';
+    case Info = 'info';
+    case Success = 'success';
+    case Warning = 'warning';
 }

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Formatter;
+
+use EliasHaeussler\CacheWarmup\Result;
+use Symfony\Component\Console;
+
+use function array_map;
+
+/**
+ * TextFormatter.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TextFormatter implements Formatter
+{
+    public function __construct(
+        private readonly Console\Style\SymfonyStyle $io,
+    ) {
+    }
+
+    public function formatParserResult(Result\ParserResult $successful, Result\ParserResult $failed): void
+    {
+        if ($this->io->isVeryVerbose()) {
+            // Print parsed sitemaps
+            $decoratedSitemaps = array_map('strval', $successful->getSitemaps());
+            $this->io->section('The following sitemaps were processed:');
+            $this->io->listing($decoratedSitemaps);
+
+            // Print parsed URLs
+            $this->io->section('The following URLs will be crawled:');
+            $this->io->listing($successful->getUrls());
+        }
+
+        // Print failed sitemaps
+        if ([] !== ($failedSitemaps = $failed->getSitemaps())) {
+            $decoratedFailedSitemaps = array_map('strval', $failedSitemaps);
+            $this->io->section('The following sitemaps could not be parsed:');
+            $this->io->listing($decoratedFailedSitemaps);
+        }
+    }
+
+    public function formatCacheWarmupResult(Result\CacheWarmupResult $result): void
+    {
+        $successfulUrls = $result->getSuccessful();
+        $failedUrls = $result->getFailed();
+
+        // Print crawler statistics
+        if ($this->io->isVeryVerbose()) {
+            $this->io->newLine();
+
+            if ([] !== $successfulUrls) {
+                $this->io->section('The following URLs were successfully crawled:');
+                $this->io->listing(array_map('strval', $successfulUrls));
+            }
+        }
+        if ($this->io->isVerbose() && [] !== $failedUrls) {
+            $this->io->section('The following URLs failed during crawling:');
+            $this->io->listing(array_map('strval', $failedUrls));
+        }
+
+        // Print crawler results
+        if ([] !== $successfulUrls) {
+            $countSuccessfulUrls = count($successfulUrls);
+            $this->io->success(
+                sprintf(
+                    'Successfully warmed up caches for %d URL%s.',
+                    $countSuccessfulUrls,
+                    1 === $countSuccessfulUrls ? '' : 's',
+                ),
+            );
+        }
+
+        if ([] !== $failedUrls) {
+            $countFailedUrls = count($failedUrls);
+            $this->io->error(
+                sprintf(
+                    'Failed to warm up caches for %d URL%s.',
+                    $countFailedUrls,
+                    1 === $countFailedUrls ? '' : 's',
+                ),
+            );
+        }
+    }
+
+    public function isVerbose(): bool
+    {
+        return true;
+    }
+
+    public static function getType(): string
+    {
+        return 'text';
+    }
+}

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -27,6 +27,7 @@ use EliasHaeussler\CacheWarmup\Result;
 use Symfony\Component\Console;
 
 use function array_map;
+use function method_exists;
 
 /**
  * TextFormatter.
@@ -102,6 +103,16 @@ final class TextFormatter implements Formatter
                     1 === $countFailedUrls ? '' : 's',
                 ),
             );
+        }
+    }
+
+    public function logMessage(string $message, MessageSeverity $severity = MessageSeverity::Info): void
+    {
+        $methodName = $severity->value;
+
+        if (method_exists($this->io, $methodName)) {
+            /* @phpstan-ignore-next-line */
+            $this->io->{$methodName}($message);
         }
     }
 

--- a/src/Result/CrawlingResult.php
+++ b/src/Result/CrawlingResult.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Result;
 
 use Psr\Http\Message;
+use Stringable;
 
 /**
  * CrawlingResult.
@@ -31,7 +32,7 @@ use Psr\Http\Message;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CrawlingResult
+final class CrawlingResult implements Stringable
 {
     /**
      * @param array<string, mixed> $data
@@ -85,5 +86,10 @@ final class CrawlingResult
     public function is(CrawlingState $state): bool
     {
         return $this->state === $state;
+    }
+
+    public function __toString(): string
+    {
+        return (string) $this->uri;
     }
 }

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit\Command;
 
 use EliasHaeussler\CacheWarmup\Command;
 use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Formatter\JsonFormatter;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use EliasHaeussler\CacheWarmup\Tests;
 use Generator;
@@ -54,6 +55,14 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         $application->add($command);
 
         $this->commandTester = new Console\Tester\CommandTester($command);
+    }
+
+    #[Framework\Attributes\Test]
+    public function initializeThrowsExceptionIfGivenFormatterIsUnsupported(): void
+    {
+        $this->expectExceptionObject(Exception\UnsupportedFormatterException::create('foo'));
+
+        $this->commandTester->execute(['--format' => 'foo']);
     }
 
     #[Framework\Attributes\Test]
@@ -406,6 +415,23 @@ final class CacheWarmupCommandTest extends Framework\TestCase
                 'https://www.example.com/sitemap.xml',
             ],
         ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeUsesConfiguredFormatter(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--format' => JsonFormatter::getType(),
+        ]);
+
+        // At this point, we cannot test the actual output of the JSON formatter
+        // because it's applied on destructuring first
+        self::assertSame('', $this->commandTester->getDisplay());
     }
 
     /**

--- a/tests/Unit/Exception/UnsupportedFormatterExceptionTest.php
+++ b/tests/Unit/Exception/UnsupportedFormatterExceptionTest.php
@@ -21,55 +21,25 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Result;
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Exception;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use PHPUnit\Framework;
 
 /**
- * CacheWarmupResult.
+ * UnsupportedFormatterExceptionTest.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CacheWarmupResult
+final class UnsupportedFormatterExceptionTest extends Framework\TestCase
 {
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $successful = [];
-
-    /**
-     * @var list<CrawlingResult>
-     */
-    private array $failed = [];
-
-    public function addResult(CrawlingResult $result): self
+    #[Framework\Attributes\Test]
+    public function createReturnsExceptionForGivenType(): void
     {
-        if ($result->isSuccessful()) {
-            $this->successful[] = $result;
-        } elseif ($result->isFailed()) {
-            $this->failed[] = $result;
-        }
+        $actual = Exception\UnsupportedFormatterException::create('foo');
 
-        return $this;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getSuccessful(): array
-    {
-        return $this->successful;
-    }
-
-    /**
-     * @return list<CrawlingResult>
-     */
-    public function getFailed(): array
-    {
-        return $this->failed;
-    }
-
-    public function isSuccessful(): bool
-    {
-        return [] === $this->failed;
+        self::assertSame(1676814093, $actual->getCode());
+        self::assertSame('The formatter "foo" is not supported.', $actual->getMessage());
     }
 }

--- a/tests/Unit/Formatter/FormatterFactoryTest.php
+++ b/tests/Unit/Formatter/FormatterFactoryTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Formatter;
+
+use EliasHaeussler\CacheWarmup as Src;
+use Generator;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * FormatterFactoryTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class FormatterFactoryTest extends Framework\TestCase
+{
+    private Console\Output\BufferedOutput $output;
+    private Src\Formatter\FormatterFactory $subject;
+
+    protected function setUp(): void
+    {
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = new Src\Formatter\FormatterFactory(
+            new Console\Style\SymfonyStyle(new Console\Input\StringInput(''), $this->output),
+        );
+    }
+
+    /**
+     * @param class-string<Src\Formatter\Formatter> $expected
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('getReturnsFormatterOfGivenTypeDataProvider')]
+    public function getReturnsFormatterOfGivenType(string $type, string $expected): void
+    {
+        self::assertInstanceOf($expected, $this->subject->get($type));
+    }
+
+    #[Framework\Attributes\Test]
+    public function getThrowsExceptionIfGivenTypeIsUnsupported(): void
+    {
+        $this->expectExceptionObject(Src\Exception\UnsupportedFormatterException::create('foo'));
+
+        $this->subject->get('foo');
+    }
+
+    /**
+     * @return Generator<string, array{string, class-string<Src\Formatter\Formatter>}>
+     */
+    public static function getReturnsFormatterOfGivenTypeDataProvider(): Generator
+    {
+        yield 'json' => ['json', Src\Formatter\JsonFormatter::class];
+        yield 'text' => ['text', Src\Formatter\TextFormatter::class];
+    }
+}

--- a/tests/Unit/Formatter/JsonFormatterTest.php
+++ b/tests/Unit/Formatter/JsonFormatterTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Unit\Formatter;
 
 use EliasHaeussler\CacheWarmup as Src;
+use Generator;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
@@ -157,5 +158,36 @@ final class JsonFormatterTest extends Framework\TestCase
             ],
             $this->subject->getJson(),
         );
+    }
+
+    /**
+     * @param array{messages: array<value-of<Src\Formatter\MessageSeverity>, list<string>>} $expected
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('logMessageAddsMessageDataProvider')]
+    public function logMessageAddsMessage(Src\Formatter\MessageSeverity $severity, array $expected): void
+    {
+        $this->subject->logMessage('foo', $severity);
+
+        self::assertSame($expected, $this->subject->getJson());
+    }
+
+    /**
+     * @return \Generator<string, array{Src\Formatter\MessageSeverity, array{messages: array<value-of<Src\Formatter\MessageSeverity>, list<string>>}}>
+     */
+    public static function logMessageAddsMessageDataProvider(): Generator
+    {
+        $message = static fn (Src\Formatter\MessageSeverity $severity) => [
+            'messages' => [
+                $severity->value => [
+                    'foo',
+                ],
+            ],
+        ];
+
+        yield 'error' => [Src\Formatter\MessageSeverity::Error, $message(Src\Formatter\MessageSeverity::Error)];
+        yield 'info' => [Src\Formatter\MessageSeverity::Info, $message(Src\Formatter\MessageSeverity::Info)];
+        yield 'success' => [Src\Formatter\MessageSeverity::Success, $message(Src\Formatter\MessageSeverity::Success)];
+        yield 'warning' => [Src\Formatter\MessageSeverity::Warning, $message(Src\Formatter\MessageSeverity::Warning)];
     }
 }

--- a/tests/Unit/Formatter/JsonFormatterTest.php
+++ b/tests/Unit/Formatter/JsonFormatterTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Formatter;
+
+use EliasHaeussler\CacheWarmup as Src;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * JsonFormatterTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class JsonFormatterTest extends Framework\TestCase
+{
+    private Console\Output\BufferedOutput $output;
+    private Src\Formatter\JsonFormatter $subject;
+
+    protected function setUp(): void
+    {
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = new Src\Formatter\JsonFormatter(
+            new Console\Style\SymfonyStyle(new Console\Input\StringInput(''), $this->output),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultDoesNotAddSuccessfulResultIfOutputIsNotVeryVerbose(): void
+    {
+        $successful = new Src\Result\ParserResult([new Src\Sitemap\Sitemap(new Psr7\Uri('https://www.example.com'))]);
+        $failed = new Src\Result\ParserResult();
+
+        $this->subject->formatParserResult($successful, $failed);
+
+        self::assertSame([], $this->subject->getJson());
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultAddsSuccessfulResultIfOutputIsVeryVerbose(): void
+    {
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        $url = 'https://www.example.com';
+        $successful = new Src\Result\ParserResult(
+            [new Src\Sitemap\Sitemap(new Psr7\Uri($url))],
+            [new Src\Sitemap\Url($url)],
+        );
+        $failed = new Src\Result\ParserResult();
+
+        $this->subject->formatParserResult($successful, $failed);
+
+        self::assertSame(
+            [
+                'parserResult' => [
+                    'success' => [
+                        'sitemaps' => [$url],
+                        'urls' => [$url],
+                    ],
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultAddsFailedResult(): void
+    {
+        $url = 'https://www.example.com';
+        $successful = new Src\Result\ParserResult();
+        $failed = new Src\Result\ParserResult([new Src\Sitemap\Sitemap(new Psr7\Uri($url))]);
+
+        $this->subject->formatParserResult($successful, $failed);
+
+        self::assertSame(
+            [
+                'parserResult' => [
+                    'failure' => [
+                        'sitemaps' => [$url],
+                    ],
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultDoesNotAddUrlsIfResultDoesNotContainUrls(): void
+    {
+        $result = new Src\Result\CacheWarmupResult();
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertSame(
+            [
+                'cacheWarmupResult' => [],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultAddsSuccessfulUrls(): void
+    {
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createSuccessful(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertSame(
+            [
+                'cacheWarmupResult' => [
+                    'success' => [$url],
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultAddsFailedUrls(): void
+    {
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createFailed(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertSame(
+            [
+                'cacheWarmupResult' => [
+                    'failure' => [$url],
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+}

--- a/tests/Unit/Formatter/TextFormatterTest.php
+++ b/tests/Unit/Formatter/TextFormatterTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Unit\Formatter;
 
 use EliasHaeussler\CacheWarmup as Src;
+use Generator;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
@@ -190,5 +191,27 @@ final class TextFormatterTest extends Framework\TestCase
         $this->subject->formatCacheWarmupResult($result);
 
         self::assertStringContainsString('Failed to warm up caches for 1 URL.', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('logMessagePrintsGivenMessageWithGivenSeverityDataProvider')]
+    public function logMessagePrintsGivenMessageWithGivenSeverity(
+        Src\Formatter\MessageSeverity $severity,
+        string $expected,
+    ): void {
+        $this->subject->logMessage('foo', $severity);
+
+        self::assertStringContainsString($expected, $this->output->fetch());
+    }
+
+    /**
+     * @return \Generator<string, array{Src\Formatter\MessageSeverity, string}>
+     */
+    public static function logMessagePrintsGivenMessageWithGivenSeverityDataProvider(): Generator
+    {
+        yield 'error' => [Src\Formatter\MessageSeverity::Error, '[ERROR] foo'];
+        yield 'info' => [Src\Formatter\MessageSeverity::Info, '[INFO] foo'];
+        yield 'success' => [Src\Formatter\MessageSeverity::Success, '[OK] foo'];
+        yield 'warning' => [Src\Formatter\MessageSeverity::Warning, '[WARNING] foo'];
     }
 }

--- a/tests/Unit/Formatter/TextFormatterTest.php
+++ b/tests/Unit/Formatter/TextFormatterTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Formatter;
+
+use EliasHaeussler\CacheWarmup as Src;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * TextFormatterTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TextFormatterTest extends Framework\TestCase
+{
+    private Console\Output\BufferedOutput $output;
+    private Src\Formatter\TextFormatter $subject;
+
+    protected function setUp(): void
+    {
+        $this->output = new Console\Output\BufferedOutput();
+        $this->subject = new Src\Formatter\TextFormatter(
+            new Console\Style\SymfonyStyle(new Console\Input\StringInput(''), $this->output),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultDoesNotPrintSuccessfulResultIfOutputIsNotVeryVerbose(): void
+    {
+        $successful = new Src\Result\ParserResult([new Src\Sitemap\Sitemap(new Psr7\Uri('https://www.example.com'))]);
+        $failed = new Src\Result\ParserResult();
+
+        $this->subject->formatParserResult($successful, $failed);
+
+        self::assertSame('', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultPrintsSuccessfulResultIfOutputIsVeryVerbose(): void
+    {
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        $url = 'https://www.example.com';
+        $successful = new Src\Result\ParserResult(
+            [new Src\Sitemap\Sitemap(new Psr7\Uri($url))],
+            [new Src\Sitemap\Url($url)],
+        );
+        $failed = new Src\Result\ParserResult();
+
+        $this->subject->formatParserResult($successful, $failed);
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('The following sitemaps were processed:', $output);
+        self::assertStringContainsString('The following URLs will be crawled:', $output);
+        self::assertStringContainsString('* https://www.example.com', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultPrintsFailedResult(): void
+    {
+        $url = 'https://www.example.com';
+        $successful = new Src\Result\ParserResult();
+        $failed = new Src\Result\ParserResult([new Src\Sitemap\Sitemap(new Psr7\Uri($url))]);
+
+        $this->subject->formatParserResult($successful, $failed);
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('The following sitemaps could not be parsed:', $output);
+        self::assertStringContainsString('* https://www.example.com', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultDoesNotPrintUrlsIfResultDoesNotContainUrls(): void
+    {
+        $result = new Src\Result\CacheWarmupResult();
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertSame('', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultDoesNotPrintSuccessfulUrlsIfOutputIsNotVeryVerbose(): void
+    {
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createSuccessful(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        $output = $this->output->fetch();
+
+        self::assertStringNotContainsString('The following URLs were successfully crawled:', $output);
+        self::assertStringNotContainsString('* https://www.example.com', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultPrintsSuccessfulUrlsIfOutputIsVeryVerbose(): void
+    {
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createSuccessful(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('The following URLs were successfully crawled:', $output);
+        self::assertStringContainsString('* https://www.example.com', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultDoesNotPrintFailedUrlsIfOutputIsNotVerbose(): void
+    {
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createFailed(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        $output = $this->output->fetch();
+
+        self::assertStringNotContainsString('The following URLs failed during crawling:', $output);
+        self::assertStringNotContainsString('* https://www.example.com', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultPrintsFailedUrlsIfOutputIsVerbose(): void
+    {
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERBOSE);
+
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createFailed(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('The following URLs failed during crawling:', $output);
+        self::assertStringContainsString('* https://www.example.com', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultPrintsResultMessageOnSuccess(): void
+    {
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createSuccessful(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertStringContainsString('Successfully warmed up caches for 1 URL.', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultPrintsResultMessageOnFailure(): void
+    {
+        $url = 'https://www.example.com';
+        $result = new Src\Result\CacheWarmupResult();
+        $result->addResult(Src\Result\CrawlingResult::createFailed(new Psr7\Uri($url)));
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertStringContainsString('Failed to warm up caches for 1 URL.', $this->output->fetch());
+    }
+}


### PR DESCRIPTION
This PR introduces the `Formatter` component for use on the command-line. At the moment, there exist two formatters:

* `Formatter\TextFormatter` (type `text`): This is the default formatter. It writes user-oriented output directly to the console. It replaces the existing user-oriented output that was previously implemented directly in the `cache-warmup` command.
* `Formatter\JsonFormatter` (type `json`): A new formatter that does not print progress-related output. Instead, it returns only a single JSON-encoded string with parser result and cache warmup result.

Formatters can be switched by passing the `--format` (shorthand: `-f`) command option.