### PR TITLE
[FEATURE] Introduce endless mode with `--repeat-after` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The following input parameters are available:
 | `--crawler-options`, `-o` | JSON-encoded string of additional config for configurable crawlers                                                                                      |
 | `--allow-failures`        | Allow failures during URL crawling and exit with zero                                                                                                   |
 | `--format`, `-f`          | Formatter used to print the cache warmup result, can be `json` or `text` *(default: `text`)*                                                            |
+| `--repeat-after`          | Run cache warmup in endless loop and repeat x seconds after each run                                                                                    |
 
 💡 Run `vendor/bin/cache-warmup --help` to see a detailed explanation of
 all available input parameters.

--- a/phpunit.coverage.xml
+++ b/phpunit.coverage.xml
@@ -4,6 +4,9 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
+    <php>
+        <env name="COLUMNS" value="300" />
+    </php>
     <testsuites>
         <testsuite name="tests">
             <directory>tests/Unit</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,6 +4,9 @@
          bootstrap="vendor/autoload.php"
          colors="true"
 >
+    <php>
+        <env name="COLUMNS" value="300" />
+    </php>
     <testsuites>
         <testsuite name="tests">
             <directory>tests/Unit</directory>

--- a/tests/Unit/Crawler/DummyCrawler.php
+++ b/tests/Unit/Crawler/DummyCrawler.php
@@ -27,6 +27,8 @@ use EliasHaeussler\CacheWarmup\Crawler;
 use EliasHaeussler\CacheWarmup\Result;
 use Psr\Http\Message;
 
+use function array_shift;
+
 /**
  * DummyCrawler.
  *
@@ -41,17 +43,19 @@ class DummyCrawler implements Crawler\CrawlerInterface
      * @var list<Message\UriInterface>
      */
     public static array $crawledUrls = [];
-    public static bool $simulateFailure = false;
+
+    /**
+     * @var list<Result\CrawlingState>
+     */
+    public static array $resultStack = [];
 
     public function crawl(array $urls): Result\CacheWarmupResult
     {
         static::$crawledUrls = $urls;
 
         $result = new Result\CacheWarmupResult();
-        $urls = $this->mapUrlsToCrawlingResults(
-            static::$crawledUrls,
-            static::$simulateFailure ? Result\CrawlingState::Failed : Result\CrawlingState::Successful,
-        );
+        $crawlingState = array_shift(static::$resultStack) ?? Result\CrawlingState::Successful;
+        $urls = $this->mapUrlsToCrawlingResults(static::$crawledUrls, $crawlingState);
 
         foreach ($urls as $crawlingResult) {
             $result->addResult($crawlingResult);


### PR DESCRIPTION
This PR introduces an "endless mode" for cache warmup on the command-line. It can be activated by passing the `--repeat-after` option to the console command. The option should provide a number in seconds that defines the interval between each iteration.

Example:

```bash
# Cache warmup will be repeated 5 minutes after each successful run
vendor/bin/cache-warmup https://www.example.com/sitemap.xml --repeat-after 300
```

> **Note** If cache warmup fails, the command will not be repeated, unless you additionally pass the `--allow-failures` option.

---

Resolves: #138