### PR TITLE
[FEATURE] Pass client to default crawlers on command-line

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -342,10 +342,10 @@ HELP);
             $crawler = new $crawler();
         } elseif ($input->getOption('progress')) {
             // Use default verbose crawler
-            $crawler = new Crawler\OutputtingCrawler();
+            $crawler = new Crawler\OutputtingCrawler(client: $this->client);
         } else {
             // Use default crawler
-            $crawler = new Crawler\ConcurrentCrawler();
+            $crawler = new Crawler\ConcurrentCrawler(client: $this->client);
         }
 
         if ($crawler instanceof Crawler\VerboseCrawlerInterface) {

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -25,7 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit\Command;
 
 use EliasHaeussler\CacheWarmup\Command;
 use EliasHaeussler\CacheWarmup\Exception;
-use EliasHaeussler\CacheWarmup\Formatter\JsonFormatter;
+use EliasHaeussler\CacheWarmup\Formatter;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use EliasHaeussler\CacheWarmup\Tests;
 use Generator;
@@ -232,7 +232,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString(' SUCCESS ', $output);
+        self::assertStringContainsString(' FAILURE ', $output);
         self::assertStringContainsString('100%', $output);
     }
 
@@ -375,7 +375,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         $output = $this->commandTester->getDisplay();
 
         self::assertSame($expected, $exitCode);
-        self::assertStringContainsString('Failed to warm up caches for 1 URL.', $output);
+        self::assertStringContainsString('Failed to warm up caches', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -426,7 +426,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
             'sitemaps' => [
                 'https://www.example.com/sitemap.xml',
             ],
-            '--format' => JsonFormatter::getType(),
+            '--format' => Formatter\JsonFormatter::getType(),
         ]);
 
         // At this point, we cannot test the actual output of the JSON formatter


### PR DESCRIPTION
In the `cache-warmup` command, a client is already initialized. However, it was not passed to the default crawlers, because of a mismatch between the Client from `psr/http-client` and Guzzle's Client that was resolved with #209. With this PR, the client is now passed to the initialized crawler.