### PR TITLE
[TASK] Move parsing of crawler options to CrawlerFactory

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -34,9 +34,6 @@ use GuzzleHttp\Psr7;
 use Symfony\Component\Console;
 
 use function count;
-use function is_array;
-use function is_string;
-use function json_decode;
 use function json_encode;
 use function sleep;
 use function sprintf;
@@ -364,7 +361,7 @@ HELP);
     {
         /** @var class-string<Crawler\CrawlerInterface>|null $crawlerClass */
         $crawlerClass = $input->getOption('crawler');
-        $crawlerOptions = $this->parseCrawlerOptions($input->getOption('crawler-options'));
+        $crawlerOptions = $this->crawlerFactory->parseCrawlerOptions($input->getOption('crawler-options'));
 
         // Select default crawler
         if (null === $crawlerClass) {
@@ -392,30 +389,6 @@ HELP);
         }
 
         return $crawler;
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    private function parseCrawlerOptions(mixed $crawlerOptions): array
-    {
-        if (null === $crawlerOptions) {
-            return [];
-        }
-
-        if (is_array($crawlerOptions)) {
-            return $crawlerOptions;
-        }
-
-        if (is_string($crawlerOptions)) {
-            $crawlerOptions = json_decode($crawlerOptions, true);
-        }
-
-        if (!is_array($crawlerOptions)) {
-            throw new Console\Exception\RuntimeException('The given crawler options are invalid. Please pass crawler options as JSON-encoded array.', 1659120649);
-        }
-
-        return $crawlerOptions;
     }
 
     private function showEndlessModeWarning(int $interval): void

--- a/src/Exception/InvalidCrawlerOptionException.php
+++ b/src/Exception/InvalidCrawlerOptionException.php
@@ -27,6 +27,7 @@ use EliasHaeussler\CacheWarmup\Crawler;
 use RuntimeException;
 
 use function count;
+use function get_debug_type;
 use function implode;
 use function sprintf;
 
@@ -62,6 +63,14 @@ final class InvalidCrawlerOptionException extends RuntimeException
                 $crawler::class,
             ),
             1659206995,
+        );
+    }
+
+    public static function forInvalidType(mixed $options): self
+    {
+        return new self(
+            sprintf('The crawler options must be an associative array, %s given.', get_debug_type($options)),
+            1677424305,
         );
     }
 }

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -305,9 +305,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function executeThrowsExceptionIfCrawlerOptionsAreInvalid(): void
     {
-        $this->expectException(Console\Exception\RuntimeException::class);
-        $this->expectExceptionCode(1659120649);
-        $this->expectExceptionMessage('The given crawler options are invalid. Please pass crawler options as JSON-encoded array.');
+        $this->expectExceptionObject(Exception\InvalidCrawlerOptionException::forInvalidType('foo'));
 
         $this->commandTester->execute([
             'sitemaps' => [

--- a/tests/Unit/Crawler/CrawlerFactoryTest.php
+++ b/tests/Unit/Crawler/CrawlerFactoryTest.php
@@ -92,4 +92,53 @@ final class CrawlerFactoryTest extends Framework\TestCase
 
         DummyVerboseCrawler::$output = null;
     }
+
+    #[Framework\Attributes\Test]
+    public function parseCrawlerOptionsReturnsEmptyArrayOnNull(): void
+    {
+        self::assertSame([], $this->subject->parseCrawlerOptions(null));
+    }
+
+    #[Framework\Attributes\Test]
+    public function parseCrawlerOptionsThrowsExceptionOnMalformedJson(): void
+    {
+        $this->expectExceptionObject(Exception\InvalidCrawlerOptionException::forInvalidType(''));
+
+        $this->subject->parseCrawlerOptions('');
+    }
+
+    #[Framework\Attributes\Test]
+    public function parseCrawlerOptionsThrowsExceptionIfJsonEncodedOptionsAreInvalid(): void
+    {
+        $this->expectExceptionObject(Exception\InvalidCrawlerOptionException::forInvalidType('"foo"'));
+
+        $this->subject->parseCrawlerOptions('"foo"');
+    }
+
+    #[Framework\Attributes\Test]
+    public function parseCrawlerOptionsThrowsExceptionOnNonAssociativeArray(): void
+    {
+        $this->expectExceptionObject(Exception\InvalidCrawlerOptionException::forInvalidType(['foo']));
+
+        /* @phpstan-ignore-next-line */
+        $this->subject->parseCrawlerOptions(['foo']);
+    }
+
+    #[Framework\Attributes\Test]
+    public function parseCrawlerOptionsCanUseJsonEncodedString(): void
+    {
+        $options = '{"foo":"baz"}';
+        $expected = ['foo' => 'baz'];
+
+        self::assertSame($expected, $this->subject->parseCrawlerOptions($options));
+    }
+
+    #[Framework\Attributes\Test]
+    public function parseCrawlerOptionsReturnsCrawlerOptions(): void
+    {
+        $options = ['foo' => 'baz'];
+        $expected = ['foo' => 'baz'];
+
+        self::assertSame($expected, $this->subject->parseCrawlerOptions($options));
+    }
 }


### PR DESCRIPTION
This allows developers to pre-parse und -validate crawler options. It also reduces the bloated cache-warmup command a little bit.