### PR TITLE
[BUGFIX] Hide crawler output if non-verbose formatter is selected

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -223,6 +223,12 @@ HELP);
     {
         $this->io = new Console\Style\SymfonyStyle($input, $output);
         $this->formatter = (new Formatter\FormatterFactory($this->io))->get($input->getOption('format'));
+
+        // Disable output if formatter is non-verbose
+        if (!$this->formatter->isVerbose()) {
+            $output = new Console\Output\NullOutput();
+        }
+
         $this->crawlerFactory = new Crawler\CrawlerFactory($output);
     }
 

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -67,6 +67,27 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function initializeHidesOutputForCrawlersIfGivenFormatterIsNotVerbose(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute(
+            [
+                'sitemaps' => [
+                    'https://www.example.com/sitemap.xml',
+                ],
+                '--format' => 'json',
+                '--progress' => true,
+            ],
+            [
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE,
+            ],
+        );
+
+        self::assertSame('', $this->commandTester->getDisplay());
+    }
+
+    #[Framework\Attributes\Test]
     public function interactThrowsExceptionIfNeitherArgumentNorInteractiveInputProvidesSitemaps(): void
     {
         $this->expectException(Console\Exception\RuntimeException::class);


### PR DESCRIPTION
In case a non-verbose formatter (e.g. `json`) is selected, crawlers must not provide any output. Otherwise, the formatted result might be invalid. Thus, we now enforce a `NullOutput` for crawlers in such cases.