### PR TITLE
[FEATURE] Introduce time tracker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 	"require": {
 		"php": "~8.1.0 || ~8.2.0",
 		"ext-filter": "*",
+		"ext-intl": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"cuyz/valinor": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd53850fc7ffd2fd336da9ddc78667d9",
+    "content-hash": "873e170553b5f0cd6cc7d7d675b3f7bf",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -5523,6 +5523,7 @@
     "platform": {
         "php": "~8.1.0 || ~8.2.0",
         "ext-filter": "*",
+        "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*"
     },

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -24,10 +24,12 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Formatter;
 
 use EliasHaeussler\CacheWarmup\Result;
+use EliasHaeussler\CacheWarmup\Time;
 use Symfony\Component\Console;
 
 use function array_map;
 use function method_exists;
+use function sprintf;
 
 /**
  * TextFormatter.
@@ -46,6 +48,7 @@ final class TextFormatter implements Formatter
         Result\ParserResult $successful,
         Result\ParserResult $failed,
         Result\ParserResult $excluded,
+        Time\Duration $duration = null,
     ): void {
         if ($this->io->isVeryVerbose()) {
             // Print parsed sitemaps
@@ -72,10 +75,17 @@ final class TextFormatter implements Formatter
             $this->io->section('The following URLs were excluded by a pattern:');
             $this->io->listing(array_map('strval', $excludedUrls));
         }
+
+        // Print duration
+        if ($this->io->isVeryVerbose() && null !== $duration) {
+            $this->io->writeln(sprintf('Parsing finished in %s', $duration->format()));
+        }
     }
 
-    public function formatCacheWarmupResult(Result\CacheWarmupResult $result): void
-    {
+    public function formatCacheWarmupResult(
+        Result\CacheWarmupResult $result,
+        Time\Duration $duration = null,
+    ): void {
         $successfulUrls = $result->getSuccessful();
         $failedUrls = $result->getFailed();
 
@@ -114,6 +124,12 @@ final class TextFormatter implements Formatter
                     1 === $countFailedUrls ? '' : 's',
                 ),
             );
+        }
+
+        // Print duration
+        if (null !== $duration) {
+            $this->io->writeln(sprintf('Crawling finished in %s', $duration->format()));
+            $this->io->newLine();
         }
     }
 

--- a/src/Time/Duration.php
+++ b/src/Time/Duration.php
@@ -21,34 +21,43 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Formatter;
+namespace EliasHaeussler\CacheWarmup\Time;
 
-use EliasHaeussler\CacheWarmup\Result;
-use EliasHaeussler\CacheWarmup\Time;
+use NumberFormatter;
 
 /**
- * Formatter.
+ * Duration.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface Formatter
+final class Duration
 {
-    public function formatParserResult(
-        Result\ParserResult $successful,
-        Result\ParserResult $failed,
-        Result\ParserResult $excluded,
-        Time\Duration $duration = null,
-    ): void;
+    private readonly NumberFormatter $formatter;
 
-    public function formatCacheWarmupResult(
-        Result\CacheWarmupResult $result,
-        Time\Duration $duration = null,
-    ): void;
+    public function __construct(
+        private readonly float $milliseconds,
+    ) {
+        $this->formatter = new NumberFormatter('en', NumberFormatter::DECIMAL);
+        $this->formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 3);
+        $this->formatter->setAttribute(NumberFormatter::DECIMAL_ALWAYS_SHOWN, 3);
+    }
 
-    public function logMessage(string $message, MessageSeverity $severity = MessageSeverity::Info): void;
+    public function get(): float
+    {
+        return $this->milliseconds;
+    }
 
-    public function isVerbose(): bool;
+    public function format(): string
+    {
+        $seconds = $this->milliseconds / 1000;
 
-    public static function getType(): string;
+        // Format with seconds
+        if ($seconds >= 0.01) {
+            return $this->formatter->format($seconds).'s';
+        }
+
+        // Format with milliseconds
+        return $this->formatter->format($this->milliseconds).'ms';
+    }
 }

--- a/tests/Unit/Formatter/JsonFormatterTest.php
+++ b/tests/Unit/Formatter/JsonFormatterTest.php
@@ -137,6 +137,26 @@ final class JsonFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function formatParserResultAddsDuration(): void
+    {
+        $successful = new Src\Result\ParserResult();
+        $failed = new Src\Result\ParserResult();
+        $excluded = new Src\Result\ParserResult();
+        $duration = new Src\Time\Duration(123.45);
+
+        $this->subject->formatParserResult($successful, $failed, $excluded, $duration);
+
+        self::assertSame(
+            [
+                'time' => [
+                    'parse' => $duration->format(),
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function formatCacheWarmupResultDoesNotAddUrlsIfResultDoesNotContainUrls(): void
     {
         $result = new Src\Result\CacheWarmupResult();
@@ -178,6 +198,24 @@ final class JsonFormatterTest extends Framework\TestCase
             [
                 'cacheWarmupResult' => [
                     'failure' => [$url],
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultAddsDuration(): void
+    {
+        $result = new Src\Result\CacheWarmupResult();
+        $duration = new Src\Time\Duration(123.45);
+
+        $this->subject->formatCacheWarmupResult($result, $duration);
+
+        self::assertSame(
+            [
+                'time' => [
+                    'crawl' => $duration->format(),
                 ],
             ],
             $this->subject->getJson(),

--- a/tests/Unit/Formatter/TextFormatterTest.php
+++ b/tests/Unit/Formatter/TextFormatterTest.php
@@ -119,6 +119,34 @@ final class TextFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function formatParserResultDoesNotPrintDurationIfOutputIsNotVeryVerbose(): void
+    {
+        $successful = new Src\Result\ParserResult();
+        $failed = new Src\Result\ParserResult();
+        $excluded = new Src\Result\ParserResult();
+        $duration = new Src\Time\Duration(500);
+
+        $this->subject->formatParserResult($successful, $failed, $excluded, $duration);
+
+        self::assertStringNotContainsString('Parsing finished in 0.5s', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultPrintsDuration(): void
+    {
+        $successful = new Src\Result\ParserResult();
+        $failed = new Src\Result\ParserResult();
+        $excluded = new Src\Result\ParserResult();
+        $duration = new Src\Time\Duration(500);
+
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+
+        $this->subject->formatParserResult($successful, $failed, $excluded, $duration);
+
+        self::assertStringContainsString('Parsing finished in 0.5s', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
     public function formatCacheWarmupResultDoesNotPrintUrlsIfResultDoesNotContainUrls(): void
     {
         $result = new Src\Result\CacheWarmupResult();
@@ -214,6 +242,17 @@ final class TextFormatterTest extends Framework\TestCase
         $this->subject->formatCacheWarmupResult($result);
 
         self::assertStringContainsString('Failed to warm up caches for 1 URL.', $this->output->fetch());
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultPrintsDuration(): void
+    {
+        $result = new Src\Result\CacheWarmupResult();
+        $duration = new Src\Time\Duration(500);
+
+        $this->subject->formatCacheWarmupResult($result, $duration);
+
+        self::assertStringContainsString('Crawling finished in 0.5s', $this->output->fetch());
     }
 
     #[Framework\Attributes\Test]

--- a/tests/Unit/Time/DurationTest.php
+++ b/tests/Unit/Time/DurationTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Time;
+
+use EliasHaeussler\CacheWarmup\Time;
+use Generator;
+use PHPUnit\Framework;
+
+/**
+ * DurationTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class DurationTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function getReturnsDurationInMilliseconds(): void
+    {
+        $subject = new Time\Duration(123.45);
+
+        self::assertSame(123.45, $subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('formatReturnsFormattedDurationDataProvider')]
+    public function formatReturnsFormattedDuration(float $milliseconds, string $expected): void
+    {
+        $subject = new Time\Duration($milliseconds);
+
+        self::assertSame($expected, $subject->format());
+    }
+
+    /**
+     * @return \Generator<string, array{float, string}>
+     */
+    public static function formatReturnsFormattedDurationDataProvider(): Generator
+    {
+        yield 'milliseconds' => [1.23456, '1.235ms'];
+        yield 'seconds' => [1234.56, '1.235s'];
+    }
+}

--- a/tests/Unit/Time/TimeTrackerTest.php
+++ b/tests/Unit/Time/TimeTrackerTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Time;
+
+use EliasHaeussler\CacheWarmup\Time;
+use Exception;
+use PHPUnit\Framework;
+
+use function sleep;
+
+/**
+ * TimeTrackerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class TimeTrackerTest extends Framework\TestCase
+{
+    private Time\TimeTracker $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Time\TimeTracker();
+    }
+
+    #[Framework\Attributes\Test]
+    public function trackTracksTimeAndReturnsResultFromFunction(): void
+    {
+        $function = function () {
+            sleep(2);
+
+            return 'foo';
+        };
+
+        self::assertNull($this->subject->getLastDuration());
+        self::assertSame('foo', $this->subject->track($function));
+        self::assertNotNull($this->subject->getLastDuration());
+        self::assertGreaterThan(2000, $this->subject->getLastDuration()->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function trackStoresDurationIfFunctionIsErroneous(): void
+    {
+        $function = static fn () => throw new Exception('dummy');
+
+        self::assertNull($this->subject->getLastDuration());
+
+        try {
+            $this->subject->track($function);
+        } catch (Exception) {
+            // Intended fallthrough.
+        }
+
+        self::assertNotNull($this->subject->getLastDuration());
+    }
+}


### PR DESCRIPTION
This PR introduces a time tracker component. It is actually only used in the cache-warmup command to track durations of URL parsing and crawling. The durations are passed along to the configured formatter.