### PR TITLE
[BUGFIX] Avoid dependency to intl extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
 	"require": {
 		"php": "~8.1.0 || ~8.2.0",
 		"ext-filter": "*",
-		"ext-intl": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"cuyz/valinor": "^1.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "873e170553b5f0cd6cc7d7d675b3f7bf",
+    "content-hash": "fd53850fc7ffd2fd336da9ddc78667d9",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -5523,7 +5523,6 @@
     "platform": {
         "php": "~8.1.0 || ~8.2.0",
         "ext-filter": "*",
-        "ext-intl": "*",
         "ext-json": "*",
         "ext-mbstring": "*"
     },

--- a/src/Time/Duration.php
+++ b/src/Time/Duration.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Time;
 
-use NumberFormatter;
+use function round;
 
 /**
  * Duration.
@@ -33,14 +33,9 @@ use NumberFormatter;
  */
 final class Duration
 {
-    private readonly NumberFormatter $formatter;
-
     public function __construct(
         private readonly float $milliseconds,
     ) {
-        $this->formatter = new NumberFormatter('en', NumberFormatter::DECIMAL);
-        $this->formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 3);
-        $this->formatter->setAttribute(NumberFormatter::DECIMAL_ALWAYS_SHOWN, 3);
     }
 
     public function get(): float
@@ -54,10 +49,10 @@ final class Duration
 
         // Format with seconds
         if ($seconds >= 0.01) {
-            return $this->formatter->format($seconds).'s';
+            return round($seconds, 3).'s';
         }
 
         // Format with milliseconds
-        return $this->formatter->format($this->milliseconds).'ms';
+        return round($this->milliseconds, 3).'ms';
     }
 }


### PR DESCRIPTION
By using the `NumberFormatter`, we add an implicit dependency to the `intl` extension. However, since this extension is not active by default, it's hard to use the library without changing the current environment. Thus, we now use the `round` function instead – which is totally enough in this case.