### PR TITLE
[TASK] Improve listing of invalid crawler options in exception message

### DIFF
--- a/src/Exception/InvalidCrawlerOptionException.php
+++ b/src/Exception/InvalidCrawlerOptionException.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Exception;
 use EliasHaeussler\CacheWarmup\Crawler;
 use RuntimeException;
 
+use function array_pop;
 use function count;
 use function get_debug_type;
 use function implode;
@@ -56,10 +57,13 @@ final class InvalidCrawlerOptionException extends RuntimeException
             return self::create($crawler, $options[0]);
         }
 
+        $lastOption = array_pop($options);
+
         return new self(
             sprintf(
-                'The crawler options "%s" are invalid or not supported by crawler "%s".',
+                'The crawler options "%s" and "%s" are invalid or not supported by crawler "%s".',
                 implode('", "', $options),
+                $lastOption,
                 $crawler::class,
             ),
             1659206995,

--- a/tests/Unit/Crawler/AbstractConfigurableCrawlerTest.php
+++ b/tests/Unit/Crawler/AbstractConfigurableCrawlerTest.php
@@ -58,7 +58,7 @@ final class AbstractConfigurableCrawlerTest extends Framework\TestCase
         $this->expectException(Exception\InvalidCrawlerOptionException::class);
         $this->expectExceptionCode(1659206995);
         $this->expectExceptionMessage(
-            'The crawler options "dummy", "blub" are invalid or not supported by crawler "'.$this->subject::class.'".',
+            'The crawler options "dummy" and "blub" are invalid or not supported by crawler "'.$this->subject::class.'".',
         );
 
         $this->subject->setOptions([

--- a/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
+++ b/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
@@ -27,6 +27,8 @@ use EliasHaeussler\CacheWarmup\Exception;
 use EliasHaeussler\CacheWarmup\Tests;
 use PHPUnit\Framework;
 
+use function sprintf;
+
 /**
  * InvalidCrawlerOptionExceptionTest.
  *
@@ -68,13 +70,17 @@ final class InvalidCrawlerOptionExceptionTest extends Framework\TestCase
         $options = [
             'foo',
             'bar',
+            'baz',
         ];
 
         $actual = Exception\InvalidCrawlerOptionException::createForAll($crawler, $options);
 
         self::assertSame(1659206995, $actual->getCode());
         self::assertSame(
-            'The crawler options "foo", "bar" are invalid or not supported by crawler "'.$crawler::class.'".',
+            sprintf(
+                'The crawler options "foo", "bar" and "baz" are invalid or not supported by crawler "%s".',
+                $crawler::class,
+            ),
             $actual->getMessage(),
         );
     }


### PR DESCRIPTION
With this PR, invalid crawler options in exception messages are now listed in a better readable way.