### PR TITLE
[!!!][FEATURE] Introduce crawling strategies

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ The following input parameters are available:
 | `--progress`, `-p`        | Show progress bar during cache warmup                                                                                                                   |
 | `--crawler`, `-c`         | FQCN of the crawler to use for cache warming (must implement [`EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface`](src/Crawler/CrawlerInterface.php)) |
 | `--crawler-options`, `-o` | JSON-encoded string of additional config for configurable crawlers                                                                                      |
+| `--strategy`, `-s`        | Optional strategy to prepare URLs before crawling them                                                                                                  |
 | `--allow-failures`        | Allow failures during URL crawling and exit with zero                                                                                                   |
 | `--format`, `-f`          | Formatter used to print the cache warmup result, can be `json` or `text` *(default: `text`)*                                                            |
 | `--repeat-after`          | Run cache warmup in endless loop and repeat x seconds after each run                                                                                    |

--- a/src/CacheWarmer.php
+++ b/src/CacheWarmer.php
@@ -79,6 +79,7 @@ final class CacheWarmer
         private readonly int $limit = 0,
         private readonly ClientInterface $client = new Client(),
         private readonly Crawler\CrawlerInterface $crawler = new Crawler\ConcurrentCrawler(),
+        private readonly ?Crawler\Strategy\CrawlingStrategy $strategy = null,
         private readonly bool $strict = true,
         private readonly array $excludePatterns = [],
     ) {
@@ -87,7 +88,13 @@ final class CacheWarmer
 
     public function run(): Result\CacheWarmupResult
     {
-        return $this->crawler->crawl($this->getUrls());
+        $urls = $this->getUrls();
+
+        if (null !== $this->strategy) {
+            $urls = $this->strategy->prepareUrls($urls);
+        }
+
+        return $this->crawler->crawl($urls);
     }
 
     /**

--- a/src/Crawler/Strategy/CrawlingStrategy.php
+++ b/src/Crawler/Strategy/CrawlingStrategy.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Sitemap;
+
+/**
+ * CrawlingStrategy.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface CrawlingStrategy
+{
+    /**
+     * @param list<Sitemap\Url> $urls
+     *
+     * @return list<Sitemap\Url>
+     */
+    public function prepareUrls(array $urls): array;
+}

--- a/src/Crawler/Strategy/SortByChangeFrequencyStrategy.php
+++ b/src/Crawler/Strategy/SortByChangeFrequencyStrategy.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Sitemap;
+
+/**
+ * SortByChangeFrequencyStrategy.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SortByChangeFrequencyStrategy extends SortingStrategy
+{
+    protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int
+    {
+        return $this->mapChangeFrequency($a->getChangeFrequency())
+            <=> $this->mapChangeFrequency($b->getChangeFrequency());
+    }
+
+    private function mapChangeFrequency(?Sitemap\ChangeFrequency $changeFrequency): int
+    {
+        return match ($changeFrequency) {
+            Sitemap\ChangeFrequency::Always => 0,
+            Sitemap\ChangeFrequency::Hourly => 10,
+            Sitemap\ChangeFrequency::Daily => 20,
+            Sitemap\ChangeFrequency::Weekly => 30,
+            Sitemap\ChangeFrequency::Monthly => 40,
+            Sitemap\ChangeFrequency::Yearly => 50,
+            default => 100,
+        };
+    }
+}

--- a/src/Crawler/Strategy/SortByLastModificationDateStrategy.php
+++ b/src/Crawler/Strategy/SortByLastModificationDateStrategy.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Sitemap;
+
+/**
+ * SortByLastModificationDateStrategy.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SortByLastModificationDateStrategy extends SortingStrategy
+{
+    protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int
+    {
+        return ($this->resolveLastModificationDate($a) <=> $this->resolveLastModificationDate($b)) * -1;
+    }
+
+    private function resolveLastModificationDate(Sitemap\Url $url): int
+    {
+        return $url->getLastModificationDate()?->getTimestamp() ?? 0;
+    }
+}

--- a/src/Crawler/Strategy/SortByPriorityStrategy.php
+++ b/src/Crawler/Strategy/SortByPriorityStrategy.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Sitemap;
+
+/**
+ * SortByPriorityStrategy.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SortByPriorityStrategy extends SortingStrategy
+{
+    protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int
+    {
+        return ($a->getPriority() <=> $b->getPriority()) * -1;
+    }
+}

--- a/src/Crawler/Strategy/SortingStrategy.php
+++ b/src/Crawler/Strategy/SortingStrategy.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Sitemap;
+
+use function array_values;
+use function usort;
+
+/**
+ * SortingStrategy.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+abstract class SortingStrategy implements CrawlingStrategy
+{
+    public function prepareUrls(array $urls): array
+    {
+        usort($urls, $this->sortUrls(...));
+
+        return array_values($urls);
+    }
+
+    abstract protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int;
+}

--- a/tests/Unit/Crawler/Strategy/SortByChangeFrequencyStrategyTest.php
+++ b/tests/Unit/Crawler/Strategy/SortByChangeFrequencyStrategyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Crawler;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use PHPUnit\Framework;
+
+/**
+ * SortByChangeFrequencyStrategyTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SortByChangeFrequencyStrategyTest extends Framework\TestCase
+{
+    private Crawler\Strategy\SortByChangeFrequencyStrategy $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Crawler\Strategy\SortByChangeFrequencyStrategy();
+    }
+
+    #[Framework\Attributes\Test]
+    public function prepareUrlsSortsGivenUrlsByPriority(): void
+    {
+        $url1 = new Sitemap\Url('https://www.example.org/foo', changeFrequency: Sitemap\ChangeFrequency::Never);
+        $url2 = new Sitemap\Url('https://www.example.org/', changeFrequency: Sitemap\ChangeFrequency::Daily);
+        $url3 = new Sitemap\Url('https://www.example.org/baz', changeFrequency: Sitemap\ChangeFrequency::Always);
+
+        self::assertSame([$url3, $url2, $url1], $this->subject->prepareUrls([$url1, $url2, $url3]));
+    }
+}

--- a/tests/Unit/Crawler/Strategy/SortByLastModificationDateStrategyTest.php
+++ b/tests/Unit/Crawler/Strategy/SortByLastModificationDateStrategyTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\Strategy;
+
+use DateTime;
+use EliasHaeussler\CacheWarmup\Crawler;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use PHPUnit\Framework;
+
+/**
+ * SortByLastModificationDateStrategyTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SortByLastModificationDateStrategyTest extends Framework\TestCase
+{
+    private Crawler\Strategy\SortByLastModificationDateStrategy $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Crawler\Strategy\SortByLastModificationDateStrategy();
+    }
+
+    #[Framework\Attributes\Test]
+    public function prepareUrlsSortsGivenUrlsByPriority(): void
+    {
+        $url1 = new Sitemap\Url('https://www.example.org/foo');
+        $url2 = new Sitemap\Url('https://www.example.org/', lastModificationDate: new DateTime('last year'));
+        $url3 = new Sitemap\Url('https://www.example.org/baz', lastModificationDate: new DateTime('last month'));
+
+        self::assertSame([$url3, $url2, $url1], $this->subject->prepareUrls([$url1, $url2, $url3]));
+    }
+}

--- a/tests/Unit/Crawler/Strategy/SortByPriorityStrategyTest.php
+++ b/tests/Unit/Crawler/Strategy/SortByPriorityStrategyTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler\Strategy;
+
+use EliasHaeussler\CacheWarmup\Crawler;
+use EliasHaeussler\CacheWarmup\Sitemap;
+use PHPUnit\Framework;
+
+/**
+ * SortByPriorityStrategyTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class SortByPriorityStrategyTest extends Framework\TestCase
+{
+    private Crawler\Strategy\SortByPriorityStrategy $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Crawler\Strategy\SortByPriorityStrategy();
+    }
+
+    #[Framework\Attributes\Test]
+    public function prepareUrlsSortsGivenUrlsByPriority(): void
+    {
+        $url1 = new Sitemap\Url('https://www.example.org/foo', 0.75);
+        $url2 = new Sitemap\Url('https://www.example.org/', 0.5);
+        $url3 = new Sitemap\Url('https://www.example.org/baz', 1.0);
+
+        self::assertSame([$url3, $url1, $url2], $this->subject->prepareUrls([$url1, $url2, $url3]));
+    }
+}


### PR DESCRIPTION
This PR introduces crawling strategies. They are used to prepare URLs before crawling them for cache warmup. At the moment, the following strategies are available:

* Sort by change frequency (`--strategy sort-by-changefreq`)
* Sort by last modification date `--strategy sort-by-lastmod`)
* Sort by priority (`--strategy sort-by-priority`)