### PR TITLE
[TASK] Use shorter crawling result badges with verbose progress handler

### DIFF
--- a/src/Http/Message/Handler/VerboseProgressHandler.php
+++ b/src/Http/Message/Handler/VerboseProgressHandler.php
@@ -64,7 +64,7 @@ final class VerboseProgressHandler implements ResponseHandlerInterface
 
     public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void
     {
-        $this->logSection->writeln(sprintf('<success> SUCCESS </success> <href=%s>%s</>', $uri, $uri));
+        $this->logSection->writeln(sprintf('<success> DONE </success> <href=%s>%s</>', $uri, $uri));
 
         $this->progressBar->advance();
         $this->progressBar->display();
@@ -72,7 +72,7 @@ final class VerboseProgressHandler implements ResponseHandlerInterface
 
     public function onFailure(Throwable $exception, Message\UriInterface $uri): void
     {
-        $this->logSection->writeln(sprintf('<failure> FAILURE </failure> <href=%s>%s</>', $uri, $uri));
+        $this->logSection->writeln(sprintf('<failure> FAIL </failure> <href=%s>%s</>', $uri, $uri));
 
         $this->progressBar->advance();
         $this->progressBar->display();

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -249,7 +249,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringNotContainsString(' SUCCESS ', $output);
+        self::assertStringNotContainsString(' DONE ', $output);
         self::assertStringContainsString('100%', $output);
     }
 
@@ -273,7 +273,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString(' SUCCESS ', $output);
+        self::assertStringContainsString(' DONE ', $output);
         self::assertStringContainsString('100%', $output);
     }
 

--- a/tests/Unit/Http/Message/Handler/VerboseProgressHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/VerboseProgressHandlerTest.php
@@ -76,7 +76,7 @@ final class VerboseProgressHandlerTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString(' SUCCESS  '.$uri, $output);
+        self::assertStringContainsString(' DONE  '.$uri, $output);
         self::assertMatchesRegularExpression('#^\s*1/10 \S+\s+10%$#m', $output);
     }
 
@@ -91,7 +91,7 @@ final class VerboseProgressHandlerTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString(' FAILURE  '.$uri, $output);
+        self::assertStringContainsString(' FAIL  '.$uri, $output);
         self::assertMatchesRegularExpression('#^\s*1/10 \S+\s+10%$#m', $output);
     }
 }


### PR DESCRIPTION
This PR changes the badges of URLs within the verbose progress handler:

* `SUCCESS` → `DONE`
* `FAILURE` → `FAIL`