### PR TITLE
[!!!][FEATURE] Send requests with default User-Agent header

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
 		"ext-filter": "*",
 		"ext-json": "*",
 		"ext-mbstring": "*",
+		"composer-runtime-api": "^2.1",
 		"cuyz/valinor": "^1.3",
 		"guzzlehttp/guzzle": "^7.0",
 		"guzzlehttp/psr7": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fd53850fc7ffd2fd336da9ddc78667d9",
+    "content-hash": "b40d0dc6e53c783b429a2abe8f97acd3",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -5652,7 +5652,8 @@
         "php": "~8.1.0 || ~8.2.0",
         "ext-filter": "*",
         "ext-json": "*",
-        "ext-mbstring": "*"
+        "ext-mbstring": "*",
+        "composer-runtime-api": "^2.1"
     },
     "platform-dev": [],
     "plugin-api-version": "2.3.0"

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
+use EliasHaeussler\CacheWarmup\Helper;
 use EliasHaeussler\CacheWarmup\Http;
 use Generator;
 use GuzzleHttp\ClientInterface;
@@ -31,6 +32,7 @@ use GuzzleHttp\Psr7;
 use Psr\Http\Message;
 
 use function array_values;
+use function sprintf;
 
 /**
  * ConcurrentCrawlerTrait.
@@ -69,8 +71,22 @@ trait ConcurrentCrawlerTrait
             yield new Psr7\Request(
                 $this->options['request_method'],
                 $url,
-                $this->options['request_headers'],
+                $this->getRequestHeaders(),
             );
         }
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function getRequestHeaders(): array
+    {
+        $currentVersion = Helper\VersionHelper::getCurrentVersion() ?? '1.0';
+        $userAgent = sprintf('EliasHaeussler-CacheWarmup/%s (https://github.com/eliashaeussler/cache-warmup)', $currentVersion);
+
+        return [
+            'User-Agent' => $userAgent,
+            ...$this->options['request_headers'],
+        ];
     }
 }

--- a/src/Helper/VersionHelper.php
+++ b/src/Helper/VersionHelper.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Helper;
+
+use Composer\InstalledVersions;
+use OutOfBoundsException;
+
+/**
+ * VersionHelper.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @codeCoverageIgnore
+ */
+final class VersionHelper
+{
+    public static function getCurrentVersion(): ?string
+    {
+        try {
+            return InstalledVersions::getPrettyVersion('eliashaeussler/cache-warmup');
+        } catch (OutOfBoundsException) {
+            return null;
+        }
+    }
+}

--- a/tests/Unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/Unit/Crawler/OutputtingCrawlerTest.php
@@ -29,6 +29,7 @@ use EliasHaeussler\CacheWarmup\Tests;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
+use Psr\Http\Message;
 use Symfony\Component\Console;
 
 /**
@@ -117,6 +118,50 @@ final class OutputtingCrawlerTest extends Framework\TestCase
         $processedUrls = $this->getProcessedUrlsFromCacheWarmupResult($result);
 
         self::assertSame([], array_diff($urls, $processedUrls));
+    }
+
+    #[Framework\Attributes\Test]
+    public function crawlSendsRequestsWithDefaultUserAgentHeader(): void
+    {
+        $this->mockHandler->append(new Psr7\Response());
+
+        $urls = [
+            new Psr7\Uri('https://www.example.org'),
+        ];
+
+        $this->subject->crawl($urls);
+
+        $lastRequest = $this->mockHandler->getLastRequest();
+
+        self::assertInstanceOf(Message\RequestInterface::class, $lastRequest);
+        self::assertStringStartsWith('EliasHaeussler-CacheWarmup/', $lastRequest->getHeader('User-Agent')[0] ?? '');
+    }
+
+    #[Framework\Attributes\Test]
+    public function crawlSendsRequestsWithOverriddenUserAgentHeader(): void
+    {
+        $this->mockHandler->append(new Psr7\Response());
+
+        $urls = [
+            new Psr7\Uri('https://www.example.org'),
+        ];
+
+        $subject = new Crawler\OutputtingCrawler(
+            [
+                'request_headers' => [
+                    'User-Agent' => 'foo',
+                ],
+            ],
+            $this->client,
+        );
+        $subject->setOutput($this->output);
+
+        $subject->crawl($urls);
+
+        $lastRequest = $this->mockHandler->getLastRequest();
+
+        self::assertInstanceOf(Message\RequestInterface::class, $lastRequest);
+        self::assertSame(['foo'], $lastRequest->getHeader('User-Agent'));
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This PR changes crawling requests to always contain a custom `User-Agent` header by default. The `User-Agent` header has the following format:

```
EliasHaeussler-CacheWarmup/<version> (https://github.com/eliashaeussler/cache-warmup
```

`<version>` is replaced by the current version of the library.

However, it's still possible to pass a custom `User-Agent` header using the crawler options:

```json
{
    "request_headers": {
        "User-Agent": "My-Custom-UA/1.0"
    }
}
```

⚠️ This is a breaking change as it requires Composer >= 2.1 to be installed.