### PR TITLE
[FEATURE] Streamline user-oriented output of sitemaps and URLs

### DIFF
--- a/src/Helper/ConsoleHelper.php
+++ b/src/Helper/ConsoleHelper.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Helper;
+
+use Symfony\Component\Console;
+
+/**
+ * ConsoleHelper.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ConsoleHelper
+{
+    public static function registerAdditionalConsoleOutputStyles(Console\Formatter\OutputFormatterInterface $formatter): void
+    {
+        $formatter->setStyle(
+            'success',
+            new Console\Formatter\OutputFormatterStyle('black', 'green'),
+        );
+        $formatter->setStyle(
+            'failure',
+            new Console\Formatter\OutputFormatterStyle('white', 'red'),
+        );
+        $formatter->setStyle(
+            'skipped',
+            new Console\Formatter\OutputFormatterStyle('black', 'yellow'),
+        );
+    }
+}

--- a/src/Http/Message/Handler/VerboseProgressHandler.php
+++ b/src/Http/Message/Handler/VerboseProgressHandler.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Http\Message\Handler;
 
+use EliasHaeussler\CacheWarmup\Helper;
 use Psr\Http\Message;
 use Symfony\Component\Console;
 use Throwable;
@@ -45,9 +46,11 @@ final class VerboseProgressHandler implements ResponseHandlerInterface
         Console\Output\ConsoleOutputInterface $output,
         int $max,
     ) {
+        Helper\ConsoleHelper::registerAdditionalConsoleOutputStyles($output->getFormatter());
+
         $this->logSection = $output->section();
         $this->progressBarSection = $output->section();
-        $this->progressBar = $this->createProgressBar($max);
+        $this->progressBar = new Console\Helper\ProgressBar($this->progressBarSection, $max);
     }
 
     public function startProgressBar(): void
@@ -76,20 +79,5 @@ final class VerboseProgressHandler implements ResponseHandlerInterface
 
         $this->progressBar->advance();
         $this->progressBar->display();
-    }
-
-    private function createProgressBar(int $max): Console\Helper\ProgressBar
-    {
-        $formatter = $this->progressBarSection->getFormatter();
-        $formatter->setStyle(
-            'success',
-            new Console\Formatter\OutputFormatterStyle('black', 'green'),
-        );
-        $formatter->setStyle(
-            'failure',
-            new Console\Formatter\OutputFormatterStyle('white', 'red'),
-        );
-
-        return new Console\Helper\ProgressBar($this->progressBarSection, $max);
     }
 }

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -116,13 +116,13 @@ final class CacheWarmupCommandTest extends Framework\TestCase
             null,
         ]);
 
-        $this->commandTester->execute([], ['verbosity' => Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE]);
+        $this->commandTester->execute([], ['verbosity' => Console\Output\OutputInterface::VERBOSITY_DEBUG]);
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
-        self::assertStringContainsString('* https://www.example.com/', $output);
-        self::assertStringContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/sitemap.xml', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/foo', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -137,15 +137,15 @@ final class CacheWarmupCommandTest extends Framework\TestCase
                 ],
             ],
             [
-                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE,
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_DEBUG,
             ],
         );
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
-        self::assertStringContainsString('* https://www.example.com/', $output);
-        self::assertStringContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/sitemap.xml', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/foo', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -161,15 +161,15 @@ final class CacheWarmupCommandTest extends Framework\TestCase
                 '--limit' => 1,
             ],
             [
-                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE,
+                'verbosity' => Console\Output\OutputInterface::VERBOSITY_DEBUG,
             ],
         );
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('* https://www.example.com/sitemap.xml', $output);
-        self::assertStringContainsString('* https://www.example.com/', $output);
-        self::assertStringNotContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/sitemap.xml', $output);
+        self::assertStringContainsString('DONE  https://www.example.com/', $output);
+        self::assertStringNotContainsString('https://www.example.com/foo', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -191,8 +191,8 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('* https://www.example.com/', $output);
-        self::assertStringContainsString('* https://www.example.com/foo', $output);
+        self::assertStringContainsString('https://www.example.com/', $output);
+        self::assertStringContainsString('https://www.example.com/foo', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -211,7 +211,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         $output = $this->commandTester->getDisplay();
 
-        self::assertStringContainsString('The following URLs were excluded by a pattern:', $output);
+        self::assertStringContainsString('SKIP  https://www.example.com/foo', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -430,7 +430,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         $output = $this->commandTester->getDisplay();
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('The following sitemaps could not be parsed:', $output);
+        self::assertStringContainsString('FAIL  https://www.example.com/sitemap.xml', $output);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/Unit/Formatter/TextFormatterTest.php
+++ b/tests/Unit/Formatter/TextFormatterTest.php
@@ -61,14 +61,14 @@ final class TextFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function formatParserResultPrintsSuccessfulResultIfOutputIsVeryVerbose(): void
+    public function formatParserResultPrintsSuccessfulSitemapsIfOutputIsVerbose(): void
     {
-        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERBOSE);
 
         $url = 'https://www.example.com';
         $successful = new Src\Result\ParserResult(
             [new Src\Sitemap\Sitemap(new Psr7\Uri($url))],
-            [new Src\Sitemap\Url($url)],
+            [new Src\Sitemap\Url($url.'/foo')],
         );
         $failed = new Src\Result\ParserResult();
         $excluded = new Src\Result\ParserResult();
@@ -77,9 +77,30 @@ final class TextFormatterTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString('The following sitemaps were processed:', $output);
-        self::assertStringContainsString('The following URLs will be crawled:', $output);
-        self::assertStringContainsString('* https://www.example.com', $output);
+        self::assertStringContainsString('Parsed sitemaps', $output);
+        self::assertStringContainsString('DONE  https://www.example.com', $output);
+        self::assertStringNotContainsString('DONE  https://www.example.com/foo', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatParserResultPrintsSuccessfulUrlsIfOutputIsDebug(): void
+    {
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_DEBUG);
+
+        $url = 'https://www.example.com';
+        $successful = new Src\Result\ParserResult(
+            [new Src\Sitemap\Sitemap(new Psr7\Uri($url))],
+            [new Src\Sitemap\Url($url.'/foo')],
+        );
+        $failed = new Src\Result\ParserResult();
+        $excluded = new Src\Result\ParserResult();
+
+        $this->subject->formatParserResult($successful, $failed, $excluded);
+
+        $output = $this->output->fetch();
+
+        self::assertStringContainsString('Parsed URLs', $output);
+        self::assertStringContainsString('DONE  https://www.example.com', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -94,8 +115,7 @@ final class TextFormatterTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString('The following sitemaps could not be parsed:', $output);
-        self::assertStringContainsString('* https://www.example.com', $output);
+        self::assertStringContainsString('FAIL  https://www.example.com', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -113,13 +133,11 @@ final class TextFormatterTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString('The following sitemaps were excluded by a pattern:', $output);
-        self::assertStringContainsString('The following URLs were excluded by a pattern:', $output);
-        self::assertStringContainsString('* https://www.example.com', $output);
+        self::assertStringContainsString('SKIP  https://www.example.com', $output);
     }
 
     #[Framework\Attributes\Test]
-    public function formatParserResultDoesNotPrintDurationIfOutputIsNotVeryVerbose(): void
+    public function formatParserResultDoesNotPrintDurationIfOutputIsNotDebug(): void
     {
         $successful = new Src\Result\ParserResult();
         $failed = new Src\Result\ParserResult();
@@ -139,7 +157,7 @@ final class TextFormatterTest extends Framework\TestCase
         $excluded = new Src\Result\ParserResult();
         $duration = new Src\Time\Duration(500);
 
-        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_DEBUG);
 
         $this->subject->formatParserResult($successful, $failed, $excluded, $duration);
 
@@ -172,9 +190,9 @@ final class TextFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function formatCacheWarmupResultPrintsSuccessfulUrlsIfOutputIsVeryVerbose(): void
+    public function formatCacheWarmupResultPrintsSuccessfulUrlsIfOutputIsDebug(): void
     {
-        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_DEBUG);
 
         $url = 'https://www.example.com';
         $result = new Src\Result\CacheWarmupResult();
@@ -184,8 +202,7 @@ final class TextFormatterTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString('The following URLs were successfully crawled:', $output);
-        self::assertStringContainsString('* https://www.example.com', $output);
+        self::assertStringContainsString('DONE  https://www.example.com', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -199,8 +216,7 @@ final class TextFormatterTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringNotContainsString('The following URLs failed during crawling:', $output);
-        self::assertStringNotContainsString('* https://www.example.com', $output);
+        self::assertStringNotContainsString('https://www.example.com', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -216,8 +232,7 @@ final class TextFormatterTest extends Framework\TestCase
 
         $output = $this->output->fetch();
 
-        self::assertStringContainsString('The following URLs failed during crawling:', $output);
-        self::assertStringContainsString('* https://www.example.com', $output);
+        self::assertStringContainsString('FAIL  https://www.example.com', $output);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/Unit/Helper/ConsoleHelperTest.php
+++ b/tests/Unit/Helper/ConsoleHelperTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Unit\Helper;
+
+use EliasHaeussler\CacheWarmup\Helper;
+use PHPUnit\Framework;
+use Symfony\Component\Console;
+
+/**
+ * ConsoleHelperTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class ConsoleHelperTest extends Framework\TestCase
+{
+    private Console\Formatter\OutputFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new Console\Formatter\OutputFormatter();
+    }
+
+    #[Framework\Attributes\Test]
+    public function registerAdditionalConsoleOutputStylesRegistersAdditionalOutputStyles(): void
+    {
+        self::assertFalse($this->formatter->hasStyle('success'));
+        self::assertFalse($this->formatter->hasStyle('failure'));
+        self::assertFalse($this->formatter->hasStyle('skipped'));
+
+        Helper\ConsoleHelper::registerAdditionalConsoleOutputStyles($this->formatter);
+
+        self::assertTrue($this->formatter->hasStyle('success'));
+        self::assertTrue($this->formatter->hasStyle('failure'));
+        self::assertTrue($this->formatter->hasStyle('skipped'));
+    }
+}


### PR DESCRIPTION
With this PR, all user-oriented output containing sitemaps or URLs is now streamlined. For this, the output styles from `VerboseProgressHandler` are now distributed through a new `ConsoleHelper` utility class.

All components with user-oriented output now register the additional output styles themselves.