### PR TITLE
[TASK] Do not install dev-dependencies for PHAR build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,6 +34,8 @@ jobs:
         run: phive install --trust-gpg-keys 2DF45277AEF09A2F humbug/box
       - name: Install Composer dependencies
         uses: ramsey/composer-install@v2
+        with:
+          composer-options: "--no-dev"
       - name: Compile PHAR
         run: ./tools/box compile --with-docker
 


### PR DESCRIPTION
This PR changes the composer installation setup for PHAR builds: dev-dependencies are no longer installed since they're not relevant for production files.