### PR TITLE
[BUGFIX] Use correct type for crawler config `request_options`

### DIFF
--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -38,8 +38,8 @@ use GuzzleHttp\ClientInterface;
  *     concurrency: int,
  *     request_method: string,
  *     request_headers: array<string, string>,
- *     request_options: array<string, string>,
- *     client_config: array<string, mixed>
+ *     request_options: array<string, mixed>,
+ *     client_config: array<string, mixed>,
  * }>
  */
 final class ConcurrentCrawler extends AbstractConfigurableCrawler

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -41,8 +41,8 @@ use function count;
  *     concurrency: int,
  *     request_method: string,
  *     request_headers: array<string, string>,
- *     request_options: array<string, string>,
- *     client_config: array<string, mixed>
+ *     request_options: array<string, mixed>,
+ *     client_config: array<string, mixed>,
  * }>
  */
 final class OutputtingCrawler extends AbstractConfigurableCrawler implements VerboseCrawlerInterface


### PR DESCRIPTION
Values of request options can be of various types. Hence, the configured type `array<string, mixed>` is to restrictive here. With this PR, it is changed to `array<string, mixed>` instead.