### PR TITLE
[BUGFIX] Avoid rate limit errors when setting up PHP in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -23,6 +23,8 @@ jobs:
         with:
           php-version: 8.1
           tools: composer:v2, composer-require-checker, composer-unused:0.7
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       # Validation
       - name: Validate composer.json


### PR DESCRIPTION
This PR fixes an issue with periodically occurring rate limit errors when setting up PHP in the CGL workflow. By providing a GitHub token, the API limit should be higher, thus calls to the GitHub API are more stable.

See https://github.com/shivammathur/setup-php#github-composer-authentication for reference.