### PR TITLE
[BUGFIX] Support <lastmod> without time

### DIFF
--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -109,7 +109,10 @@ final class XmlParser
                     throw $exception;
                 },
             )
-            ->supportDateFormats(DateTimeInterface::W3C)
+            ->supportDateFormats(
+                DateTimeInterface::W3C,
+                '!Y-m-d',
+            )
             ->mapper()
         ;
     }

--- a/tests/Unit/Fixtures/valid_sitemap_5.xml
+++ b/tests/Unit/Fixtures/valid_sitemap_5.xml
@@ -3,7 +3,7 @@
     <url>
         <loc>https://www.example.org/</loc>
         <priority>0.8</priority>
-        <lastmod>2022-05-02T12:14:44+02:00</lastmod>
+        <lastmod>2022-05-02</lastmod>
         <changefreq>yearly</changefreq>
     </url>
     <url>

--- a/tests/Unit/Mapper/Source/XmlSourceTest.php
+++ b/tests/Unit/Mapper/Source/XmlSourceTest.php
@@ -59,7 +59,7 @@ final class XmlSourceTest extends Framework\TestCase
                 [
                     'loc' => 'https://www.example.org/',
                     'priority' => '0.8',
-                    'lastmod' => '2022-05-02T12:14:44+02:00',
+                    'lastmod' => '2022-05-02',
                     'changefreq' => 'yearly',
                 ],
                 [

--- a/tests/Unit/Xml/XmlParserTest.php
+++ b/tests/Unit/Xml/XmlParserTest.php
@@ -82,7 +82,7 @@ final class XmlParserTest extends Framework\TestCase
             new Sitemap\Url(
                 uri: 'https://www.example.org/',
                 priority: 0.8,
-                lastModificationDate: new DateTimeImmutable('2022-05-02T12:14:44+02:00'),
+                lastModificationDate: new DateTimeImmutable('2022-05-02T00:00:00+00:00'),
                 changeFrequency: Sitemap\ChangeFrequency::Yearly,
             ),
             new Sitemap\Url(


### PR DESCRIPTION
The W3C specification allows a date to be specified without time. Since this is also documented in various places where XML sitemaps are promoted, `cache-warmup` now supports this format as well.

Resolves: #247