### PR TITLE
[TASK] Exclude `.editorconfig` from dist archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,7 @@
 /.github                  export-ignore
 /docs                     export-ignore
 /tests                    export-ignore
+/.editorconfig            export-ignore
 /.gitattributes           export-ignore
 /.gitignore               export-ignore
 /.php-cs-fixer.php        export-ignore


### PR DESCRIPTION
The `.editorconfig` file must not be present in dist archives as it's only relevant for development.