### PR TITLE
[FEATURE] Publish Docker image to GHCR

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -78,7 +78,9 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: eliashaeussler/cache-warmup
+          images: |
+            eliashaeussler/cache-warmup
+            ghcr.io/eliashaeussler/cache-warmup
           tags: |
             type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' }}
             type=semver,pattern={{version}}
@@ -96,6 +98,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Login at GitHub container registry
+      - name: Login to GHCR
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Build and push image
       - name: Build and push

--- a/README.md
+++ b/README.md
@@ -56,6 +56,12 @@ phive install cache-warmup
 docker run --rm -it eliashaeussler/cache-warmup
 ```
 
+You can also use the image from [GitHub Container Registry][21]:
+
+```bash
+docker run --rm -it ghcr.io/eliashaeussler/cache-warmup
+```
+
 ### Composer
 
 [![Packagist](https://img.shields.io/packagist/v/eliashaeussler/cache-warmup?label=version&logo=packagist)](https://packagist.org/packages/eliashaeussler/cache-warmup)
@@ -435,3 +441,4 @@ This project is licensed under [GNU General Public License 3.0 (or later)](LICEN
 [18]: https://docs.guzzlephp.org/en/stable/request-options.html
 [19]: https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client
 [20]: https://github.com/eliashaeussler/cache-warmup/releases/latest
+[21]: https://github.com/eliashaeussler/cache-warmup/pkgs/container/cache-warmup


### PR DESCRIPTION
With this PR, Docker images will now be published to GitHub Container Registry as well.