### PR TITLE
[FEATURE] Store origin in parsed sitemaps and urls

### DIFF
--- a/src/Sitemap/Sitemap.php
+++ b/src/Sitemap/Sitemap.php
@@ -44,6 +44,7 @@ class Sitemap implements Stringable
     public function __construct(
         protected Message\UriInterface $uri,
         protected ?DateTimeInterface $lastModificationDate = null,
+        protected ?self $origin = null,
     ) {
         $this->validateUri();
     }
@@ -56,6 +57,23 @@ class Sitemap implements Stringable
     public function getLastModificationDate(): ?DateTimeInterface
     {
         return $this->lastModificationDate;
+    }
+
+    public function getOrigin(): ?self
+    {
+        return $this->origin;
+    }
+
+    public function getRootOrigin(): ?self
+    {
+        return $this->origin?->getRootOrigin() ?? $this->origin;
+    }
+
+    public function setOrigin(self $origin): self
+    {
+        $this->origin = $origin;
+
+        return $this;
     }
 
     public function __toString(): string

--- a/src/Sitemap/Url.php
+++ b/src/Sitemap/Url.php
@@ -46,6 +46,7 @@ class Url extends Psr7\Uri
         protected float $priority = 0.5,
         protected ?DateTimeInterface $lastModificationDate = null,
         protected ?ChangeFrequency $changeFrequency = null,
+        protected ?Sitemap $origin = null,
     ) {
         parent::__construct($uri);
         $this->validateUri();
@@ -69,5 +70,22 @@ class Url extends Psr7\Uri
     public function getChangeFrequency(): ?ChangeFrequency
     {
         return $this->changeFrequency;
+    }
+
+    public function getOrigin(): ?Sitemap
+    {
+        return $this->origin;
+    }
+
+    public function getRootOrigin(): ?Sitemap
+    {
+        return $this->origin?->getRootOrigin() ?? $this->origin;
+    }
+
+    public function setOrigin(Sitemap $origin): self
+    {
+        $this->origin = $origin;
+
+        return $this;
     }
 }

--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -85,10 +85,20 @@ final class XmlParser
 
         // Map XML source
         try {
-            return $this->mapper->map(Result\ParserResult::class, $source);
+            $result = $this->mapper->map(Result\ParserResult::class, $source);
         } catch (Valinor\Mapper\MappingError $error) {
             throw Exception\InvalidSitemapException::create($sitemap, $error);
         }
+
+        // Apply origin to sitemaps and urls
+        foreach ($result->getSitemaps() as $parsedSitemap) {
+            $parsedSitemap->setOrigin($sitemap);
+        }
+        foreach ($result->getUrls() as $parsedUrl) {
+            $parsedUrl->setOrigin($sitemap);
+        }
+
+        return $result;
     }
 
     private function createMapper(): Valinor\Mapper\TreeMapper

--- a/tests/Unit/CacheWarmerTest.php
+++ b/tests/Unit/CacheWarmerTest.php
@@ -139,9 +139,11 @@ final class CacheWarmerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function addSitemapsIgnoresSitemapsIfLimitWasExceeded(): void
     {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap.xml'));
+
         $subject = new CacheWarmer(limit: 1, client: $this->client);
         $expected = [
-            new Sitemap\Url('https://www.example.org/'),
+            new Sitemap\Url('https://www.example.org/', origin: $origin),
         ];
 
         $this->mockSitemapRequest('valid_sitemap_2');
@@ -158,6 +160,8 @@ final class CacheWarmerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function addSitemapsIgnoresSitemapsIfExcludePatternMatches(): void
     {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap.xml'));
+
         $subject = new CacheWarmer(client: $this->client, excludePatterns: ['*/foo', '#www\\.example\\.com#']);
 
         $this->mockSitemapRequest('valid_sitemap_2');
@@ -173,7 +177,7 @@ final class CacheWarmerTest extends Framework\TestCase
         );
         self::assertEquals(
             [
-                new Sitemap\Url('https://www.example.org/foo'),
+                new Sitemap\Url('https://www.example.org/foo', origin: $origin),
             ],
             $subject->getExcludedUrls(),
         );
@@ -185,8 +189,8 @@ final class CacheWarmerTest extends Framework\TestCase
         );
         self::assertEquals(
             [
-                new Sitemap\Url('https://www.example.org/'),
-                new Sitemap\Url('https://www.example.org/baz'),
+                new Sitemap\Url('https://www.example.org/', origin: $origin),
+                new Sitemap\Url('https://www.example.org/baz', origin: $origin),
             ],
             $subject->getUrls(),
         );
@@ -267,10 +271,19 @@ final class CacheWarmerTest extends Framework\TestCase
     }
 
     /**
-     * @return Generator<string, array{0: list<string|Sitemap\Sitemap>|string|Sitemap\Sitemap, 1: list<Sitemap\Sitemap>, 2: list<Sitemap\Url>, 3?: list<string>}>
+     * @return Generator<string, array{
+     *     0: list<string|Sitemap\Sitemap>|string|Sitemap\Sitemap,
+     *     1: list<Sitemap\Sitemap>,
+     *     2: list<Sitemap\Url>,
+     *     3?: list<string>,
+     * }>
      */
     public static function addSitemapsAddsAndParsesGivenSitemapsDataProvider(): Generator
     {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap.xml'));
+        $origin2 = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.com/sitemap.xml'));
+        $origin3 = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap_en.xml'), origin: $origin2);
+
         yield 'empty sitemaps' => [
             [],
             [],
@@ -282,9 +295,9 @@ final class CacheWarmerTest extends Framework\TestCase
                 new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap.xml')),
             ],
             [
-                new Sitemap\Url('https://www.example.org/'),
-                new Sitemap\Url('https://www.example.org/foo'),
-                new Sitemap\Url('https://www.example.org/baz'),
+                new Sitemap\Url('https://www.example.org/', origin: $origin),
+                new Sitemap\Url('https://www.example.org/foo', origin: $origin),
+                new Sitemap\Url('https://www.example.org/baz', origin: $origin),
             ],
             [
                 'valid_sitemap_2',
@@ -296,9 +309,9 @@ final class CacheWarmerTest extends Framework\TestCase
                 new Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap.xml')),
             ],
             [
-                new Sitemap\Url('https://www.example.org/'),
-                new Sitemap\Url('https://www.example.org/foo'),
-                new Sitemap\Url('https://www.example.org/baz'),
+                new Sitemap\Url('https://www.example.org/', origin: $origin),
+                new Sitemap\Url('https://www.example.org/foo', origin: $origin),
+                new Sitemap\Url('https://www.example.org/baz', origin: $origin),
             ],
             [
                 'valid_sitemap_2',
@@ -314,11 +327,11 @@ final class CacheWarmerTest extends Framework\TestCase
                 new Sitemap\Sitemap(self::getExpectedUri('https://www.example.com/sitemap.xml')),
             ],
             [
-                new Sitemap\Url('https://www.example.org/'),
-                new Sitemap\Url('https://www.example.org/foo'),
-                new Sitemap\Url('https://www.example.org/baz'),
-                new Sitemap\Url('https://www.example.com/'),
-                new Sitemap\Url('https://www.example.com/foo'),
+                new Sitemap\Url('https://www.example.org/', origin: $origin),
+                new Sitemap\Url('https://www.example.org/foo', origin: $origin),
+                new Sitemap\Url('https://www.example.org/baz', origin: $origin),
+                new Sitemap\Url('https://www.example.com/', origin: $origin2),
+                new Sitemap\Url('https://www.example.com/foo', origin: $origin2),
             ],
             [
                 'valid_sitemap_2',
@@ -335,11 +348,11 @@ final class CacheWarmerTest extends Framework\TestCase
                 new Sitemap\Sitemap(self::getExpectedUri('https://www.example.com/sitemap.xml')),
             ],
             [
-                new Sitemap\Url('https://www.example.org/'),
-                new Sitemap\Url('https://www.example.org/foo'),
-                new Sitemap\Url('https://www.example.org/baz'),
-                new Sitemap\Url('https://www.example.com/'),
-                new Sitemap\Url('https://www.example.com/foo'),
+                new Sitemap\Url('https://www.example.org/', origin: $origin),
+                new Sitemap\Url('https://www.example.org/foo', origin: $origin),
+                new Sitemap\Url('https://www.example.org/baz', origin: $origin),
+                new Sitemap\Url('https://www.example.com/', origin: $origin2),
+                new Sitemap\Url('https://www.example.com/foo', origin: $origin2),
             ],
             [
                 'valid_sitemap_2',
@@ -354,14 +367,14 @@ final class CacheWarmerTest extends Framework\TestCase
             [
                 new Sitemap\Sitemap(self::getExpectedUri('https://www.example.org/sitemap.xml')),
                 new Sitemap\Sitemap(self::getExpectedUri('https://www.example.com/sitemap.xml')),
-                new Sitemap\Sitemap(self::getExpectedUri('https://www.example.org/sitemap_en.xml')),
+                new Sitemap\Sitemap(self::getExpectedUri('https://www.example.org/sitemap_en.xml'), origin: $origin2),
             ],
             [
-                new Sitemap\Url('https://www.example.org/'),
-                new Sitemap\Url('https://www.example.org/foo'),
-                new Sitemap\Url('https://www.example.org/baz'),
-                new Sitemap\Url('https://www.example.com/'),
-                new Sitemap\Url('https://www.example.com/foo'),
+                new Sitemap\Url('https://www.example.org/', origin: $origin),
+                new Sitemap\Url('https://www.example.org/foo', origin: $origin),
+                new Sitemap\Url('https://www.example.org/baz', origin: $origin),
+                new Sitemap\Url('https://www.example.com/', origin: $origin3),
+                new Sitemap\Url('https://www.example.com/foo', origin: $origin3),
             ],
             [
                 'valid_sitemap_2',

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -30,6 +30,7 @@ use EliasHaeussler\CacheWarmup\Result;
 use EliasHaeussler\CacheWarmup\Sitemap;
 use EliasHaeussler\CacheWarmup\Tests;
 use Generator;
+use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 
@@ -306,6 +307,8 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function executeUsesCustomCrawler(): void
     {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://www.example.com/sitemap.xml'));
+
         $this->mockSitemapRequest('valid_sitemap_3');
 
         $this->commandTester->execute([
@@ -316,8 +319,8 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         ]);
 
         $expected = [
-            new Sitemap\Url('https://www.example.com/'),
-            new Sitemap\Url('https://www.example.com/foo'),
+            new Sitemap\Url('https://www.example.com/', origin: $origin),
+            new Sitemap\Url('https://www.example.com/foo', origin: $origin),
         ];
 
         self::assertEquals($expected, Tests\Unit\Crawler\DummyCrawler::$crawledUrls);

--- a/tests/Unit/Sitemap/SitemapTest.php
+++ b/tests/Unit/Sitemap/SitemapTest.php
@@ -77,6 +77,27 @@ final class SitemapTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function constructorAssignsOriginCorrectly(): void
+    {
+        $uri = new Psr7\Uri('https://foo.baz');
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'));
+        $subject = new Sitemap\Sitemap($uri, origin: $origin);
+
+        self::assertSame($origin, $subject->getOrigin());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getRootOriginReturnsRootOrigin(): void
+    {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'));
+        $origin2 = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'), origin: $origin);
+        $origin3 = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'), origin: $origin2);
+        $subject = new Sitemap\Sitemap(new Psr7\Uri('https://foo.baz'), origin: $origin3);
+
+        self::assertSame($origin, $subject->getRootOrigin());
+    }
+
+    #[Framework\Attributes\Test]
     public function stringRepresentationReturnsUri(): void
     {
         $uri = new Psr7\Uri('https://foo.baz');

--- a/tests/Unit/Sitemap/UrlTest.php
+++ b/tests/Unit/Sitemap/UrlTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Unit\Sitemap;
 use DateTimeImmutable;
 use EliasHaeussler\CacheWarmup\Exception;
 use EliasHaeussler\CacheWarmup\Sitemap;
+use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 
 /**
@@ -88,5 +89,25 @@ final class UrlTest extends Framework\TestCase
         $subject = new Sitemap\Url('https://foo.baz', changeFrequency: $changeFrequency);
 
         self::assertSame($changeFrequency, $subject->getChangeFrequency());
+    }
+
+    #[Framework\Attributes\Test]
+    public function constructorAssignsOriginCorrectly(): void
+    {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'));
+        $subject = new Sitemap\Url('https://foo.baz', origin: $origin);
+
+        self::assertSame($origin, $subject->getOrigin());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getRootOriginReturnsRootOrigin(): void
+    {
+        $origin = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'));
+        $origin2 = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'), origin: $origin);
+        $origin3 = new Sitemap\Sitemap(new Psr7\Uri('https://baz.foo'), origin: $origin2);
+        $subject = new Sitemap\Url('https://foo.baz', origin: $origin3);
+
+        self::assertSame($origin, $subject->getRootOrigin());
     }
 }

--- a/tests/Unit/Xml/XmlParserTest.php
+++ b/tests/Unit/Xml/XmlParserTest.php
@@ -64,6 +64,7 @@ final class XmlParserTest extends Framework\TestCase
             new Sitemap\Sitemap(
                 uri: new Psr7\Uri('https://www.example.org/sitemap_en.xml'),
                 lastModificationDate: new DateTimeImmutable('2022-08-17T13:18:06+02:00'),
+                origin: $this->sitemap,
             ),
         ];
 
@@ -84,18 +85,21 @@ final class XmlParserTest extends Framework\TestCase
                 priority: 0.8,
                 lastModificationDate: new DateTimeImmutable('2022-05-02T00:00:00+00:00'),
                 changeFrequency: Sitemap\ChangeFrequency::Yearly,
+                origin: $this->sitemap,
             ),
             new Sitemap\Url(
                 uri: 'https://www.example.org/foo',
                 priority: 0.5,
                 lastModificationDate: new DateTimeImmutable('2021-06-07T20:01:25+02:00'),
                 changeFrequency: Sitemap\ChangeFrequency::Monthly,
+                origin: $this->sitemap,
             ),
             new Sitemap\Url(
                 uri: 'https://www.example.org/baz',
                 priority: 0.5,
                 lastModificationDate: new DateTimeImmutable('2021-05-28T11:54:00+02:00'),
                 changeFrequency: Sitemap\ChangeFrequency::Hourly,
+                origin: $this->sitemap,
             ),
         ];
 
@@ -111,8 +115,8 @@ final class XmlParserTest extends Framework\TestCase
         $result = $this->subject->parse($this->sitemap);
 
         $expected = [
-            new Sitemap\Url('https://www.example.com/'),
-            new Sitemap\Url('https://www.example.com/foo'),
+            new Sitemap\Url('https://www.example.com/', origin: $this->sitemap),
+            new Sitemap\Url('https://www.example.com/foo', origin: $this->sitemap),
         ];
 
         self::assertEquals($expected, $result->getUrls());


### PR DESCRIPTION
This PR extends the `XmlParser` to store the original sitemap in parsed sitemaps and urls. They can then be accessed wherever sitemaps and urls are passed around, for example in the `CacheWarmer` or within custom crawler implementations.