### PR TITLE
[FEATURE] Let crawling strategies provide their identifiers

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -70,6 +70,9 @@ final class CacheWarmupCommand extends Console\Command\Command
         $configurableCrawlerInterface = Crawler\ConfigurableCrawlerInterface::class;
         $textFormatter = Formatter\TextFormatter::getType();
         $jsonFormatter = Formatter\JsonFormatter::getType();
+        $sortByChangeFrequencyStrategy = Crawler\Strategy\SortByChangeFrequencyStrategy::getName();
+        $sortByLastModificationDateStrategy = Crawler\Strategy\SortByLastModificationDateStrategy::getName();
+        $sortByPriorityStrategy = Crawler\Strategy\SortByPriorityStrategy::getName();
 
         $this->setDescription('Warms up caches of URLs provided by a given set of XML sitemaps.');
         $this->setHelp(<<<HELP
@@ -143,13 +146,13 @@ it is possible to pass a JSON-encoded array of crawler options by using the <com
 URLs can be crawled using a specific crawling strategy, e.g. by sorting them by a specific property.
 For this, use the <comment>--strategy</comment> option together with a predefined value:
 
-   <comment>%command.full_name% --strategy sort-by-priority</comment>
+   <comment>%command.full_name% --strategy {$sortByPriorityStrategy}</comment>
 
 The following strategies are currently available:
 
-   * <comment>sort-by-changefreq</comment>
-   * <comment>sort-by-lastmod</comment>
-   * <comment>sort-by-priority</comment>
+   * <comment>{$sortByChangeFrequencyStrategy}</comment>
+   * <comment>{$sortByLastModificationDateStrategy}</comment>
+   * <comment>{$sortByPriorityStrategy}</comment>
 
 <info>Allow failures</info>
 <info>==============</info>
@@ -372,9 +375,9 @@ HELP);
 
         // Initialize crawling strategy
         $strategy = match ($input->getOption('strategy')) {
-            'sort-by-changefreq' => new Crawler\Strategy\SortByChangeFrequencyStrategy(),
-            'sort-by-lastmod' => new Crawler\Strategy\SortByLastModificationDateStrategy(),
-            'sort-by-priority' => new Crawler\Strategy\SortByPriorityStrategy(),
+            Crawler\Strategy\SortByChangeFrequencyStrategy::getName() => new Crawler\Strategy\SortByChangeFrequencyStrategy(),
+            Crawler\Strategy\SortByLastModificationDateStrategy::getName() => new Crawler\Strategy\SortByLastModificationDateStrategy(),
+            Crawler\Strategy\SortByPriorityStrategy::getName() => new Crawler\Strategy\SortByPriorityStrategy(),
             null => null,
             default => throw new Console\Exception\RuntimeException('The given crawling strategy is invalid.', 1677618007),
         };

--- a/src/Crawler/Strategy/CrawlingStrategy.php
+++ b/src/Crawler/Strategy/CrawlingStrategy.php
@@ -39,4 +39,9 @@ interface CrawlingStrategy
      * @return list<Sitemap\Url>
      */
     public function prepareUrls(array $urls): array;
+
+    /**
+     * @return non-empty-string
+     */
+    public static function getName(): string;
 }

--- a/src/Crawler/Strategy/SortByChangeFrequencyStrategy.php
+++ b/src/Crawler/Strategy/SortByChangeFrequencyStrategy.php
@@ -33,6 +33,11 @@ use EliasHaeussler\CacheWarmup\Sitemap;
  */
 final class SortByChangeFrequencyStrategy extends SortingStrategy
 {
+    public static function getName(): string
+    {
+        return 'sort-by-changefreq';
+    }
+
     protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int
     {
         return $this->mapChangeFrequency($a->getChangeFrequency())

--- a/src/Crawler/Strategy/SortByLastModificationDateStrategy.php
+++ b/src/Crawler/Strategy/SortByLastModificationDateStrategy.php
@@ -33,6 +33,11 @@ use EliasHaeussler\CacheWarmup\Sitemap;
  */
 final class SortByLastModificationDateStrategy extends SortingStrategy
 {
+    public static function getName(): string
+    {
+        return 'sort-by-lastmod';
+    }
+
     protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int
     {
         return ($this->resolveLastModificationDate($a) <=> $this->resolveLastModificationDate($b)) * -1;

--- a/src/Crawler/Strategy/SortByPriorityStrategy.php
+++ b/src/Crawler/Strategy/SortByPriorityStrategy.php
@@ -33,6 +33,11 @@ use EliasHaeussler\CacheWarmup\Sitemap;
  */
 final class SortByPriorityStrategy extends SortingStrategy
 {
+    public static function getName(): string
+    {
+        return 'sort-by-priority';
+    }
+
     protected function sortUrls(Sitemap\Url $a, Sitemap\Url $b): int
     {
         return ($a->getPriority() <=> $b->getPriority()) * -1;


### PR DESCRIPTION
Crawling strategies are now enforced to provider their identifiers. This is achieved by providing a static method `getName()`.