### PR TITLE
[FEATURE] Introduce support for PSR-3 loggers

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,6 +12,7 @@
 /composer.lock            export-ignore
 /CONTRIBUTING.md          export-ignore
 /phpstan.php              export-ignore
+/phpstan-baseline.neon    export-ignore
 /phpunit.xml              export-ignore
 /rector.php               export-ignore
 /renovate.json            export-ignore

--- a/README.md
+++ b/README.md
@@ -246,6 +246,48 @@ $ cache-warmup --format json
 | Multiple values allowed | **–**      |
 | Default                 | **`text`** |
 
+#### `--log-file`
+
+A file where to log crawling results. Implicitly enables logging,
+if the options is set.
+
+```bash
+$ cache-warmup --log-file cache-warmup.log
+```
+
+| Shorthand               | –     |
+|:------------------------|:------|
+| Required                | **–** |
+| Multiple values allowed | **–** |
+| Default                 | **–** |
+
+#### `--log-level`
+
+The log level used to determine which crawling results to log. This
+option is only respected if the [`--log-file`](#--log-file) command
+option is set.
+
+The following log levels are available:
+
+* `emergency`
+* `alert`
+* `critical`
+* `error` (default; enables logging of failed crawls)
+* `warning`
+* `notice`
+* `info` (enables logging of successful crawls)
+* `debug`
+
+```bash
+$ cache-warmup --log-level error
+```
+
+| Shorthand               | –                                        |
+|:------------------------|:-----------------------------------------|
+| Required                | **✅**                                    |
+| Multiple values allowed | **–**                                    |
+| Default                 | **`error`** *(= log only failed crawls)* |
+
 #### `--allow-failures`
 
 Allow failures during URL crawling and exit with zero.

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,9 @@
 		"guzzlehttp/psr7": "^2.0",
 		"mtownsend/xml-to-array": "^2.0",
 		"psr/http-message": "^1.0 || ^2.0",
-		"symfony/console": "^5.4 || ^6.0"
+		"psr/log": "^2.0 || ^3.0",
+		"symfony/console": "^5.4 || ^6.0",
+		"symfony/filesystem": "^5.4 || ^6.0"
 	},
 	"require-dev": {
 		"armin/editorconfig-cli": "^1.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d3dcdee018ceed77405081c419c61e47",
+    "content-hash": "49d26c5caa32970ffc09fd445e7a4ff8",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -671,6 +671,56 @@
             "time": "2023-04-04T09:54:51+00:00"
         },
         {
+            "name": "psr/log",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/3.0.0"
+            },
+            "time": "2021-07-14T16:46:02+00:00"
+        },
+        {
             "name": "psr/simple-cache",
             "version": "3.0.0",
             "source": {
@@ -921,6 +971,69 @@
                 }
             ],
             "time": "2023-05-23T14:45:45+00:00"
+        },
+        {
+            "name": "symfony/filesystem",
+            "version": "v6.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/filesystem.git",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-mbstring": "~1.8"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Filesystem\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides basic utilities for the filesystem",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-06-01T08:30:39+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -3765,56 +3878,6 @@
             "time": "2019-01-08T18:20:26+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
-            },
-            "time": "2021-07-14T16:46:02+00:00"
-        },
-        {
             "name": "rector/rector",
             "version": "0.17.12",
             "source": {
@@ -4936,69 +4999,6 @@
                 }
             ],
             "time": "2023-05-23T14:45:45+00:00"
-        },
-        {
-            "name": "symfony/filesystem",
-            "version": "v6.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/filesystem.git",
-                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
-                "reference": "edd36776956f2a6fcf577edb5b05eb0e3bdc52ae",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-mbstring": "~1.8"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Filesystem\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides basic utilities for the filesystem",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.3.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-06-01T08:30:39+00:00"
         },
         {
             "name": "symfony/finder",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,41 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Parameter \\#1 \\$level \\('alert'\\|'critical'\\|'debug'\\|'emergency'\\|'error'\\|'info'\\|'notice'\\|'warning'\\) of method EliasHaeussler\\\\CacheWarmup\\\\Log\\\\FileLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\AbstractLogger\\:\\:log\\(\\)$#"
+			count: 1
+			path: src/Log/FileLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$level \\('alert'\\|'critical'\\|'debug'\\|'emergency'\\|'error'\\|'info'\\|'notice'\\|'warning'\\) of method EliasHaeussler\\\\CacheWarmup\\\\Log\\\\FileLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\LoggerInterface\\:\\:log\\(\\)$#"
+			count: 1
+			path: src/Log/FileLogger.php
+
+		-
+			message: "#^Parameter \\#3 \\$context \\(array\\<string, mixed\\>\\) of method EliasHaeussler\\\\CacheWarmup\\\\Log\\\\FileLogger\\:\\:log\\(\\) should be contravariant with parameter \\$context \\(array\\) of method Psr\\\\Log\\\\AbstractLogger\\:\\:log\\(\\)$#"
+			count: 1
+			path: src/Log/FileLogger.php
+
+		-
+			message: "#^Parameter \\#3 \\$context \\(array\\<string, mixed\\>\\) of method EliasHaeussler\\\\CacheWarmup\\\\Log\\\\FileLogger\\:\\:log\\(\\) should be contravariant with parameter \\$context \\(array\\) of method Psr\\\\Log\\\\LoggerInterface\\:\\:log\\(\\)$#"
+			count: 1
+			path: src/Log/FileLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$level \\('alert'\\|'critical'\\|'debug'\\|'emergency'\\|'error'\\|'info'\\|'notice'\\|'warning'\\) of method EliasHaeussler\\\\CacheWarmup\\\\Tests\\\\Log\\\\DummyLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\AbstractLogger\\:\\:log\\(\\)$#"
+			count: 1
+			path: tests/src/Log/DummyLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$level \\('alert'\\|'critical'\\|'debug'\\|'emergency'\\|'error'\\|'info'\\|'notice'\\|'warning'\\) of method EliasHaeussler\\\\CacheWarmup\\\\Tests\\\\Log\\\\DummyLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\LoggerInterface\\:\\:log\\(\\)$#"
+			count: 1
+			path: tests/src/Log/DummyLogger.php
+
+		-
+			message: "#^Parameter \\#3 \\$context \\(array\\<string, mixed\\>\\) of method EliasHaeussler\\\\CacheWarmup\\\\Tests\\\\Log\\\\DummyLogger\\:\\:log\\(\\) should be contravariant with parameter \\$context \\(array\\) of method Psr\\\\Log\\\\AbstractLogger\\:\\:log\\(\\)$#"
+			count: 1
+			path: tests/src/Log/DummyLogger.php
+
+		-
+			message: "#^Parameter \\#3 \\$context \\(array\\<string, mixed\\>\\) of method EliasHaeussler\\\\CacheWarmup\\\\Tests\\\\Log\\\\DummyLogger\\:\\:log\\(\\) should be contravariant with parameter \\$context \\(array\\) of method Psr\\\\Log\\\\LoggerInterface\\:\\:log\\(\\)$#"
+			count: 1
+			path: tests/src/Log/DummyLogger.php

--- a/src/Crawler/CrawlerFactory.php
+++ b/src/Crawler/CrawlerFactory.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
 use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Log;
 use JsonException;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\Console;
 
 use function class_exists;
@@ -42,6 +44,8 @@ final class CrawlerFactory
 {
     public function __construct(
         private readonly Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
+        private readonly ?LoggerInterface $logger = null,
+        private readonly Log\LogLevel $logLevel = Log\LogLevel::Error,
     ) {
     }
 
@@ -63,6 +67,11 @@ final class CrawlerFactory
 
         if ($crawler instanceof ConfigurableCrawlerInterface) {
             $crawler->setOptions($options);
+        }
+
+        if ($crawler instanceof LoggingCrawlerInterface && null !== $this->logger) {
+            $crawler->setLogger($this->logger);
+            $crawler->setLogLevel($this->logLevel);
         }
 
         return $crawler;

--- a/src/Crawler/LoggingCrawlerInterface.php
+++ b/src/Crawler/LoggingCrawlerInterface.php
@@ -21,21 +21,20 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig;
+namespace EliasHaeussler\CacheWarmup\Crawler;
 
-$symfonySet = PHPStanConfig\Set\SymfonySet::create()
-    ->withConsoleApplicationLoader('tests/build/console-application.php')
-;
+use EliasHaeussler\CacheWarmup\Log;
+use Psr\Log\LoggerInterface;
 
-return PHPStanConfig\Config\Config::create(__DIR__)
-    ->in(
-        'bin/cache-warmup',
-        'src',
-        'tests',
-    )
-    ->withBaseline()
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->withSets($symfonySet)
-    ->toArray()
-;
+/**
+ * LoggingCrawlerInterface.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface LoggingCrawlerInterface extends CrawlerInterface
+{
+    public function setLogger(LoggerInterface $logger): void;
+
+    public function setLogLevel(Log\LogLevel $logLevel): void;
+}

--- a/src/Exception/FilesystemFailureException.php
+++ b/src/Exception/FilesystemFailureException.php
@@ -21,21 +21,28 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig;
+namespace EliasHaeussler\CacheWarmup\Exception;
 
-$symfonySet = PHPStanConfig\Set\SymfonySet::create()
-    ->withConsoleApplicationLoader('tests/build/console-application.php')
-;
+use function sprintf;
 
-return PHPStanConfig\Config\Config::create(__DIR__)
-    ->in(
-        'bin/cache-warmup',
-        'src',
-        'tests',
-    )
-    ->withBaseline()
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->withSets($symfonySet)
-    ->toArray()
-;
+/**
+ * FilesystemFailureException.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class FilesystemFailureException extends Exception
+{
+    public static function forUnresolvableWorkingDirectory(): self
+    {
+        return new self('Unable to resolve the current working directory.', 1691648735);
+    }
+
+    public static function forUnexpectedFileStreamResult(string $file): self
+    {
+        return new self(
+            sprintf('Unable to open a file stream for "%s".', $file),
+            1691649034,
+        );
+    }
+}

--- a/src/Exception/UnsupportedLogLevelException.php
+++ b/src/Exception/UnsupportedLogLevelException.php
@@ -21,21 +21,23 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig;
+namespace EliasHaeussler\CacheWarmup\Exception;
 
-$symfonySet = PHPStanConfig\Set\SymfonySet::create()
-    ->withConsoleApplicationLoader('tests/build/console-application.php')
-;
+use function sprintf;
 
-return PHPStanConfig\Config\Config::create(__DIR__)
-    ->in(
-        'bin/cache-warmup',
-        'src',
-        'tests',
-    )
-    ->withBaseline()
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->withSets($symfonySet)
-    ->toArray()
-;
+/**
+ * UnsupportedLogLevelException.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class UnsupportedLogLevelException extends Exception
+{
+    public static function create(string $logLevel): self
+    {
+        return new self(
+            sprintf('The log level "%s" is not supported.', $logLevel),
+            1691597515,
+        );
+    }
+}

--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Helper;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use Symfony\Component\Filesystem;
+
+/**
+ * FilesystemHelper.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class FilesystemHelper
+{
+    public static function resolveRelativePath(string $relativePath): string
+    {
+        if (Filesystem\Path::isAbsolute($relativePath)) {
+            return $relativePath;
+        }
+
+        return Filesystem\Path::makeAbsolute($relativePath, self::getWorkingDirectory());
+    }
+
+    public static function getWorkingDirectory(): string
+    {
+        $cwd = realpath((string) getcwd());
+
+        if (false === $cwd) {
+            throw Exception\FilesystemFailureException::forUnresolvableWorkingDirectory();
+        }
+
+        return Filesystem\Path::canonicalize($cwd);
+    }
+}

--- a/src/Log/FileLogger.php
+++ b/src/Log/FileLogger.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Log;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use EliasHaeussler\CacheWarmup\Helper;
+use Psr\Log;
+use Stringable;
+
+use function dirname;
+use function fclose;
+use function file_exists;
+use function fopen;
+use function fwrite;
+use function is_dir;
+use function is_resource;
+use function mkdir;
+use function touch;
+
+/**
+ * FileLogger.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class FileLogger extends Log\AbstractLogger
+{
+    private readonly string $file;
+    private bool $fileCreated = false;
+
+    /**
+     * @var resource|null
+     */
+    private $stream;
+
+    public function __construct(
+        string $file,
+        private readonly Formatter\LogFormatter $formatter = new Formatter\CompactLogFormatter(),
+    ) {
+        $this->file = Helper\FilesystemHelper::resolveRelativePath($file);
+    }
+
+    /**
+     * @phpstan-param Log\LogLevel::* $level
+     *
+     * @param array<string, mixed> $context
+     *
+     * @throws Exception\FilesystemFailureException
+     */
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        if (!is_resource($this->stream)) {
+            $this->stream = $this->openStream();
+        }
+
+        $logLevel = LogLevel::fromPsrLogLevel($level);
+        $formatted = $this->formatter->format($logLevel, $message, $context);
+
+        fwrite($this->stream, $formatted.PHP_EOL);
+    }
+
+    /**
+     * @return resource
+     *
+     * @throws Exception\FilesystemFailureException
+     */
+    private function openStream()
+    {
+        $this->createLogFileIfNotExists();
+
+        $stream = fopen($this->file, 'a');
+
+        if (!is_resource($stream)) {
+            throw Exception\FilesystemFailureException::forUnexpectedFileStreamResult($this->file);
+        }
+
+        return $stream;
+    }
+
+    private function closeStream(): void
+    {
+        if (is_resource($this->stream)) {
+            fclose($this->stream);
+        }
+
+        $this->fileCreated = false;
+        $this->stream = null;
+    }
+
+    private function createLogFileIfNotExists(): void
+    {
+        // Don't try to create file multiple times
+        if ($this->fileCreated) {
+            return;
+        }
+
+        // Assure directory exists
+        if (!is_dir(dirname($this->file))) {
+            mkdir(dirname($this->file), recursive: true);
+        }
+
+        // Create file if not exists
+        if (!file_exists($this->file)) {
+            touch($this->file);
+        }
+
+        // Set flag to not create file multiple times
+        $this->fileCreated = true;
+    }
+
+    public function __destruct()
+    {
+        $this->closeStream();
+    }
+}

--- a/src/Log/Formatter/CompactLogFormatter.php
+++ b/src/Log/Formatter/CompactLogFormatter.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Log\Formatter;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use EliasHaeussler\CacheWarmup\Log;
+use JsonSerializable;
+use Stringable;
+
+use function get_debug_type;
+use function is_scalar;
+use function json_encode;
+use function preg_replace_callback;
+use function sprintf;
+use function strtoupper;
+
+/**
+ * CompactLogFormatter.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class CompactLogFormatter implements LogFormatter
+{
+    private const TEMPLATE = '[%s] %s: %s %s';
+
+    public function format(Log\LogLevel $level, Stringable|string $message, array $context = []): string
+    {
+        $date = new DateTimeImmutable();
+        $formattedMessage = $this->formatMessage($message, $context);
+        $context = $this->formatContext($context);
+
+        return sprintf(
+            self::TEMPLATE,
+            $date->format(DateTimeInterface::ATOM),
+            strtoupper($level->name),
+            $formattedMessage,
+            json_encode($context),
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function formatMessage(Stringable|string $message, array &$context = []): string
+    {
+        $formattedMessage = preg_replace_callback(
+            '/\{([^\s}]+)}/',
+            function (array $matches) use (&$context) {
+                return $this->replacePlaceholder($matches[0], $matches[1], $context);
+            },
+            (string) $message,
+        );
+
+        // Return original message on failures
+        if (null === $formattedMessage) {
+            return (string) $message;
+        }
+
+        return $formattedMessage;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function replacePlaceholder(string $placeholder, string $placeholderKey, array &$context): string
+    {
+        // Keep placeholder if no replacement is available
+        if (!isset($context[$placeholderKey])) {
+            return $placeholder;
+        }
+
+        // Replace placeholder value
+        $value = $context[$placeholderKey];
+
+        if (!is_scalar($value) && !($value instanceof Stringable)) {
+            return $placeholder;
+        }
+
+        // Remove processed placeholder from context
+        unset($context[$placeholderKey]);
+
+        return (string) $value;
+    }
+
+    /**
+     * @param array<string, mixed> $context
+     *
+     * @return array<string, mixed>
+     */
+    private function formatContext(array $context): array
+    {
+        foreach ($context as $key => $value) {
+            if (is_scalar($value) || $value instanceof Stringable || $value instanceof JsonSerializable) {
+                continue;
+            }
+
+            $context[$key] = get_debug_type($value);
+        }
+
+        return $context;
+    }
+}

--- a/src/Log/Formatter/LogFormatter.php
+++ b/src/Log/Formatter/LogFormatter.php
@@ -21,21 +21,21 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig;
+namespace EliasHaeussler\CacheWarmup\Log\Formatter;
 
-$symfonySet = PHPStanConfig\Set\SymfonySet::create()
-    ->withConsoleApplicationLoader('tests/build/console-application.php')
-;
+use EliasHaeussler\CacheWarmup\Log;
+use Stringable;
 
-return PHPStanConfig\Config\Config::create(__DIR__)
-    ->in(
-        'bin/cache-warmup',
-        'src',
-        'tests',
-    )
-    ->withBaseline()
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->withSets($symfonySet)
-    ->toArray()
-;
+/**
+ * LogFormatter.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface LogFormatter
+{
+    /**
+     * @param array<string, mixed> $context
+     */
+    public function format(Log\LogLevel $level, Stringable|string $message, array $context = []): string;
+}

--- a/src/Log/LogLevel.php
+++ b/src/Log/LogLevel.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Log;
+
+use EliasHaeussler\CacheWarmup\Exception;
+use Psr\Log;
+
+use function strtolower;
+
+/**
+ * LogLevel.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+enum LogLevel: int
+{
+    case Emergency = 7;
+    case Alert = 6;
+    case Critical = 5;
+    case Error = 4;
+    case Warning = 3;
+    case Notice = 2;
+    case Info = 1;
+    case Debug = 0;
+
+    public function satisfies(self $other): bool
+    {
+        return $this->value <= $other->value;
+    }
+
+    /**
+     * @throws Exception\UnsupportedLogLevelException
+     */
+    public static function fromName(string $level): self
+    {
+        return match (strtolower($level)) {
+            'emergency' => self::Emergency,
+            'alert' => self::Alert,
+            'critical' => self::Critical,
+            'error' => self::Error,
+            'warning' => self::Warning,
+            'notice' => self::Notice,
+            'info' => self::Info,
+            'debug' => self::Debug,
+            default => throw Exception\UnsupportedLogLevelException::create($level),
+        };
+    }
+
+    /**
+     * @phpstan-param Log\LogLevel::* $psrLogLevel
+     */
+    public static function fromPsrLogLevel(string $psrLogLevel): self
+    {
+        return match ($psrLogLevel) {
+            Log\LogLevel::EMERGENCY => self::Emergency,
+            Log\LogLevel::ALERT => self::Alert,
+            Log\LogLevel::CRITICAL => self::Critical,
+            Log\LogLevel::ERROR => self::Error,
+            Log\LogLevel::WARNING => self::Warning,
+            Log\LogLevel::NOTICE => self::Notice,
+            Log\LogLevel::INFO => self::Info,
+            Log\LogLevel::DEBUG => self::Debug,
+        };
+    }
+}

--- a/tests/src/Command/CacheWarmupCommandTest.php
+++ b/tests/src/Command/CacheWarmupCommandTest.php
@@ -30,7 +30,10 @@ use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 use Symfony\Component\Console;
 
+use function file_get_contents;
 use function implode;
+use function sys_get_temp_dir;
+use function uniqid;
 
 /**
  * CacheWarmupCommandTest.
@@ -481,6 +484,24 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         // At this point, we cannot test the actual output of the JSON formatter
         // because it's applied on destructuring first
         self::assertSame('', $this->commandTester->getDisplay());
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeLogsCrawlingResults(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
+        $logFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('cache-warmup_tests_').DIRECTORY_SEPARATOR.'test.log';
+
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--log-file' => $logFile,
+        ]);
+
+        self::assertFileExists($logFile);
+        self::assertNotEmpty((string) file_get_contents($logFile));
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/src/Crawler/ConcurrentCrawlerTest.php
@@ -186,4 +186,25 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
         self::assertSame($urls, $this->getProcessedUrlsFromCacheWarmupResult($result, Src\Result\CrawlingState::Failed));
         self::assertSame([], $result->getSuccessful());
     }
+
+    #[Framework\Attributes\Test]
+    public function crawlLogsCrawlingResults(): void
+    {
+        $logger = new Tests\Log\DummyLogger();
+
+        $this->mockHandler->append(
+            new Psr7\Response(),
+            new Psr7\Response(404),
+        );
+
+        $uri1 = new Psr7\Uri('https://www.example.org');
+        $uri2 = new Psr7\Uri('https://www.foo.baz');
+
+        $this->subject->setLogger($logger);
+        $this->subject->setLogLevel(Src\Log\LogLevel::Info);
+        $this->subject->crawl([$uri1, $uri2]);
+
+        self::assertCount(1, $logger->log[Src\Log\LogLevel::Error->value]);
+        self::assertCount(1, $logger->log[Src\Log\LogLevel::Info->value]);
+    }
 }

--- a/tests/src/Crawler/CrawlerFactoryTest.php
+++ b/tests/src/Crawler/CrawlerFactoryTest.php
@@ -37,12 +37,14 @@ use Symfony\Component\Console;
 final class CrawlerFactoryTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;
+    private Src\Tests\Log\DummyLogger $logger;
     private Src\Crawler\CrawlerFactory $subject;
 
     protected function setUp(): void
     {
         $this->output = new Console\Output\BufferedOutput();
-        $this->subject = new Src\Crawler\CrawlerFactory($this->output);
+        $this->logger = new Src\Tests\Log\DummyLogger();
+        $this->subject = new Src\Crawler\CrawlerFactory($this->output, $this->logger);
     }
 
     #[Framework\Attributes\Test]
@@ -91,6 +93,19 @@ final class CrawlerFactoryTest extends Framework\TestCase
         self::assertSame($this->output, DummyVerboseCrawler::$output);
 
         DummyVerboseCrawler::$output = null;
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsLoggingCrawler(): void
+    {
+        $actual = $this->subject->get(DummyLoggingCrawler::class);
+
+        self::assertInstanceOf(DummyLoggingCrawler::class, $actual);
+        self::assertSame($this->logger, DummyLoggingCrawler::$logger);
+        self::assertSame(Src\Log\LogLevel::Error, DummyLoggingCrawler::$logLevel);
+
+        DummyLoggingCrawler::$logger = null;
+        DummyLoggingCrawler::$logLevel = null;
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Crawler/DummyLoggingCrawler.php
+++ b/tests/src/Crawler/DummyLoggingCrawler.php
@@ -21,21 +21,32 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig;
+namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
 
-$symfonySet = PHPStanConfig\Set\SymfonySet::create()
-    ->withConsoleApplicationLoader('tests/build/console-application.php')
-;
+use EliasHaeussler\CacheWarmup\Crawler;
+use EliasHaeussler\CacheWarmup\Log;
+use Psr\Log\LoggerInterface;
 
-return PHPStanConfig\Config\Config::create(__DIR__)
-    ->in(
-        'bin/cache-warmup',
-        'src',
-        'tests',
-    )
-    ->withBaseline()
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->withSets($symfonySet)
-    ->toArray()
-;
+/**
+ * DummyLoggingCrawler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class DummyLoggingCrawler extends DummyCrawler implements Crawler\LoggingCrawlerInterface
+{
+    public static ?LoggerInterface $logger = null;
+    public static ?Log\LogLevel $logLevel = null;
+
+    public function setLogger(LoggerInterface $logger): void
+    {
+        self::$logger = $logger;
+    }
+
+    public function setLogLevel(Log\LogLevel $logLevel): void
+    {
+        self::$logLevel = $logLevel;
+    }
+}

--- a/tests/src/Crawler/OutputtingCrawlerTest.php
+++ b/tests/src/Crawler/OutputtingCrawlerTest.php
@@ -237,4 +237,25 @@ final class OutputtingCrawlerTest extends Framework\TestCase
         self::assertStringContainsString('DONE  https://www.example.org', $output);
         self::assertStringContainsString('FAIL  https://www.foo.baz', $output);
     }
+
+    #[Framework\Attributes\Test]
+    public function crawlLogsCrawlingResults(): void
+    {
+        $logger = new Tests\Log\DummyLogger();
+
+        $this->mockHandler->append(
+            new Psr7\Response(),
+            new Psr7\Response(404),
+        );
+
+        $uri1 = new Psr7\Uri('https://www.example.org');
+        $uri2 = new Psr7\Uri('https://www.foo.baz');
+
+        $this->subject->setLogger($logger);
+        $this->subject->setLogLevel(Src\Log\LogLevel::Info);
+        $this->subject->crawl([$uri1, $uri2]);
+
+        self::assertCount(1, $logger->log[Src\Log\LogLevel::Error->value]);
+        self::assertCount(1, $logger->log[Src\Log\LogLevel::Info->value]);
+    }
 }

--- a/tests/src/Exception/FilesystemFailureExceptionTest.php
+++ b/tests/src/Exception/FilesystemFailureExceptionTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Exception;
+
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
+
+/**
+ * FilesystemFailureExceptionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\FilesystemFailureException::class)]
+final class FilesystemFailureExceptionTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function forUnresolvableWorkingDirectoryReturnsExceptionForUnresolvableWorkingDirectory(): void
+    {
+        $actual = Src\Exception\FilesystemFailureException::forUnresolvableWorkingDirectory();
+
+        self::assertSame(1691648735, $actual->getCode());
+        self::assertSame('Unable to resolve the current working directory.', $actual->getMessage());
+    }
+
+    #[Framework\Attributes\Test]
+    public function forUnexpectedFileStreamResultReturnsExceptionForUnexpectedFileStreamResult(): void
+    {
+        $actual = Src\Exception\FilesystemFailureException::forUnexpectedFileStreamResult('foo');
+
+        self::assertSame(1691649034, $actual->getCode());
+        self::assertSame('Unable to open a file stream for "foo".', $actual->getMessage());
+    }
+}

--- a/tests/src/Exception/UnsupportedLogLevelExceptionTest.php
+++ b/tests/src/Exception/UnsupportedLogLevelExceptionTest.php
@@ -21,21 +21,26 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-use EliasHaeussler\PHPStanConfig;
+namespace EliasHaeussler\CacheWarmup\Tests\Exception;
 
-$symfonySet = PHPStanConfig\Set\SymfonySet::create()
-    ->withConsoleApplicationLoader('tests/build/console-application.php')
-;
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
 
-return PHPStanConfig\Config\Config::create(__DIR__)
-    ->in(
-        'bin/cache-warmup',
-        'src',
-        'tests',
-    )
-    ->withBaseline()
-    ->withBleedingEdge()
-    ->maxLevel()
-    ->withSets($symfonySet)
-    ->toArray()
-;
+/**
+ * UnsupportedLogLevelExceptionTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\UnsupportedLogLevelException::class)]
+final class UnsupportedLogLevelExceptionTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function createReturnsExceptionForUnsupportedLogLevel(): void
+    {
+        $actual = Src\Exception\UnsupportedLogLevelException::create('foo');
+
+        self::assertSame(1691597515, $actual->getCode());
+        self::assertSame('The log level "foo" is not supported.', $actual->getMessage());
+    }
+}

--- a/tests/src/Helper/FilesystemHelperTest.php
+++ b/tests/src/Helper/FilesystemHelperTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Helper;
+
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
+
+/**
+ * FilesystemHelperTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Helper\FilesystemHelper::class)]
+final class FilesystemHelperTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function resolveRelativePathReturnsAbsolutePathIfGivenPathIsAbsolute(): void
+    {
+        self::assertSame('/foo', Src\Helper\FilesystemHelper::resolveRelativePath('/foo'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function resolveRelativePathPrependsProjectRootPath(): void
+    {
+        $currentWorkingDirectory = getcwd();
+        $projectRootPath = __DIR__.'/..';
+        $expected = dirname(__DIR__).'/foo/baz';
+
+        self::assertNotFalse($currentWorkingDirectory, 'Unable to get current working directory.');
+
+        chdir($projectRootPath);
+
+        self::assertSame($expected, Src\Helper\FilesystemHelper::resolveRelativePath('foo/baz'));
+
+        chdir($currentWorkingDirectory);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getWorkingDirectoryReturnsCurrentWorkingDirectory(): void
+    {
+        $cwd = dirname(__DIR__, 3);
+
+        self::assertSame($cwd, Src\Helper\FilesystemHelper::getWorkingDirectory());
+
+        chdir(__DIR__);
+
+        self::assertSame(__DIR__, Src\Helper\FilesystemHelper::getWorkingDirectory());
+
+        chdir($cwd);
+    }
+}

--- a/tests/src/Http/Message/Handler/LogHandlerTest.php
+++ b/tests/src/Http/Message/Handler/LogHandlerTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Http\Message\Handler;
+
+use EliasHaeussler\CacheWarmup as Src;
+use EliasHaeussler\CacheWarmup\Tests;
+use Exception;
+use GuzzleHttp\Psr7;
+use PHPUnit\Framework;
+
+/**
+ * LogHandlerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Http\Message\Handler\LogHandler::class)]
+final class LogHandlerTest extends Framework\TestCase
+{
+    private Tests\Log\DummyLogger $logger;
+    private Src\Http\Message\Handler\LogHandler $subject;
+
+    protected function setUp(): void
+    {
+        $this->logger = new Tests\Log\DummyLogger();
+        $this->subject = new Src\Http\Message\Handler\LogHandler($this->logger);
+    }
+
+    #[Framework\Attributes\Test]
+    public function onSuccessDoesNothingIfConfiguredLogLevelDoesNotSatisfyInfoLevel(): void
+    {
+        $this->subject->onSuccess(
+            new Psr7\Response(),
+            new Psr7\Uri('https://www.example.com'),
+        );
+
+        self::assertSame([], $this->logger->log[Src\Log\LogLevel::Info->value]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function onSuccessLogsSuccessfulCrawl(): void
+    {
+        $expected = [
+            [
+                'message' => 'URL {url} was successfully crawled (status code: {status_code}).',
+                'context' => [
+                    'url' => 'https://www.example.com',
+                    'status_code' => 200,
+                ],
+            ],
+        ];
+
+        $subject = new Src\Http\Message\Handler\LogHandler($this->logger, Src\Log\LogLevel::Info);
+
+        $subject->onSuccess(
+            new Psr7\Response(),
+            new Psr7\Uri('https://www.example.com'),
+        );
+
+        self::assertSame($expected, $this->logger->log[Src\Log\LogLevel::Info->value]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function onFailureDoesNothingIfConfiguredLogLevelDoesNotSatisfyErrorLevel(): void
+    {
+        $subject = new Src\Http\Message\Handler\LogHandler($this->logger, Src\Log\LogLevel::Emergency);
+
+        $subject->onFailure(
+            new Exception(),
+            new Psr7\Uri('https://www.example.com'),
+        );
+
+        self::assertSame([], $this->logger->log[Src\Log\LogLevel::Info->value]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function onFailureLogsFailedCrawl(): void
+    {
+        $expected = [
+            [
+                'message' => 'Error while crawling URL {url} (exception: {exception}).',
+                'context' => [
+                    'url' => 'https://www.example.com',
+                    'exception' => 'oops, something went wrong.',
+                ],
+            ],
+        ];
+
+        $this->subject->onFailure(
+            new Exception('oops, something went wrong.'),
+            new Psr7\Uri('https://www.example.com'),
+        );
+
+        self::assertSame($expected, $this->logger->log[Src\Log\LogLevel::Error->value]);
+    }
+}

--- a/tests/src/Log/DummyLogger.php
+++ b/tests/src/Log/DummyLogger.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Log;
+
+use EliasHaeussler\CacheWarmup\Log;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LogLevel;
+use Stringable;
+
+/**
+ * DummyLogger.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class DummyLogger extends AbstractLogger
+{
+    /**
+     * @var array<value-of<Log\LogLevel>, list<array{message: string|Stringable, context: array<string, mixed>}>>
+     */
+    public array $log = [];
+
+    public function __construct()
+    {
+        foreach (Log\LogLevel::cases() as $logLevel) {
+            $this->log[$logLevel->value] = [];
+        }
+    }
+
+    /**
+     * @phpstan-param LogLevel::* $level
+     *
+     * @param array<string, mixed> $context
+     */
+    public function log($level, Stringable|string $message, array $context = []): void
+    {
+        $logLevel = Log\LogLevel::fromPsrLogLevel($level);
+
+        $this->log[$logLevel->value][] = [
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/tests/src/Log/FileLoggerTest.php
+++ b/tests/src/Log/FileLoggerTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Log;
+
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
+use Psr\Log;
+
+use function dirname;
+use function file_exists;
+use function file_get_contents;
+use function rmdir;
+use function sys_get_temp_dir;
+use function uniqid;
+use function unlink;
+
+/**
+ * FileLoggerTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Log\FileLogger::class)]
+final class FileLoggerTest extends Framework\TestCase
+{
+    private string $logFile;
+    private Src\Log\FileLogger $subject;
+
+    protected function setUp(): void
+    {
+        $this->logFile = sys_get_temp_dir().DIRECTORY_SEPARATOR.uniqid('cache-warmup_tests_').DIRECTORY_SEPARATOR.'test.log';
+        $this->subject = new Src\Log\FileLogger($this->logFile);
+    }
+
+    #[Framework\Attributes\Test]
+    public function logCreatesLogFileIfNotExists(): void
+    {
+        $this->subject->log(Log\LogLevel::ERROR, 'oops, something went wrong.');
+
+        self::assertFileExists($this->logFile);
+    }
+
+    #[Framework\Attributes\Test]
+    public function logDoesNotTryToCreateLogFileMultipleTimes(): void
+    {
+        $this->subject->log(Log\LogLevel::ERROR, 'oops, something went wrong.');
+
+        unlink($this->logFile);
+
+        $this->subject->log(Log\LogLevel::ERROR, 'oops, something went wrong.');
+
+        self::assertFileDoesNotExist($this->logFile);
+    }
+
+    #[Framework\Attributes\Test]
+    public function logLogsFormattedMessageToLogFile(): void
+    {
+        $this->subject->log(Log\LogLevel::ERROR, 'oops, something went wrong.');
+
+        $fileContents = file_get_contents($this->logFile);
+
+        self::assertNotEmpty($fileContents);
+        self::assertStringContainsString('ERROR: oops, something went wrong.', $fileContents);
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->logFile)) {
+            unlink($this->logFile);
+            rmdir(dirname($this->logFile));
+        }
+    }
+}

--- a/tests/src/Log/Formatter/CompactLogFormatterTest.php
+++ b/tests/src/Log/Formatter/CompactLogFormatterTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Log\Formatter;
+
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
+use stdClass;
+
+/**
+ * CompactLogFormatterTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Log\Formatter\CompactLogFormatter::class)]
+final class CompactLogFormatterTest extends Framework\TestCase
+{
+    private Src\Log\Formatter\CompactLogFormatter $subject;
+
+    protected function setUp(): void
+    {
+        $this->subject = new Src\Log\Formatter\CompactLogFormatter();
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatReplacesPlaceholdersInMessage(): void
+    {
+        $context = [
+            'foo' => 'baz',
+        ];
+
+        self::assertStringEndsWith(
+            'ERROR: oops, a baz occurred. []',
+            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.', $context),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatPrintsContextWithNonReplacedPlaceholders(): void
+    {
+        $context = [
+            'foo' => 'baz',
+            'baz' => 'foo',
+        ];
+
+        self::assertStringEndsWith(
+            'ERROR: oops, a baz occurred. {"baz":"foo"}',
+            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.', $context),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatSkipsNonStringablePlaceholderValues(): void
+    {
+        $context = [
+            'foo' => new stdClass(),
+        ];
+
+        self::assertStringEndsWith(
+            'ERROR: oops, a {foo} occurred. {"foo":"stdClass"}',
+            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.', $context),
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function formatSkipsPlaceholdersWithoutValueInContext(): void
+    {
+        self::assertStringEndsWith(
+            'ERROR: oops, a {foo} occurred. []',
+            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.'),
+        );
+    }
+}

--- a/tests/src/Log/LogLevelTest.php
+++ b/tests/src/Log/LogLevelTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Log;
+
+use EliasHaeussler\CacheWarmup as Src;
+use Generator;
+use PHPUnit\Framework;
+use Psr\Log;
+
+/**
+ * LogLevelTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Log\LogLevel::class)]
+final class LogLevelTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function satisfiesReturnsTrueIfLogLevelSatisfiesGivenLogLevel(): void
+    {
+        $subject = Src\Log\LogLevel::Warning;
+
+        self::assertTrue($subject->satisfies(Src\Log\LogLevel::Error));
+        self::assertFalse($subject->satisfies(Src\Log\LogLevel::Notice));
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('fromNameReturnsLogLevelFromGivenNameDataProvider')]
+    public function fromNameReturnsLogLevelFromGivenName(string $level, Src\Log\LogLevel $expected): void
+    {
+        self::assertSame($expected, Src\Log\LogLevel::fromName($level));
+    }
+
+    #[Framework\Attributes\Test]
+    public function fromNameThrowsExceptionOnUnsupportedLogLevel(): void
+    {
+        $this->expectExceptionObject(Src\Exception\UnsupportedLogLevelException::create('foo'));
+
+        Src\Log\LogLevel::fromName('foo');
+    }
+
+    /**
+     * @phpstan-param Log\LogLevel::* $level
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('fromPsrLogLevelReturnsLogLevelFromGivenPsrLogLevelDataProvider')]
+    public function fromPsrLogLevelReturnsLogLevelFromGivenPsrLogLevel(string $level, Src\Log\LogLevel $expected): void
+    {
+        self::assertSame($expected, Src\Log\LogLevel::fromPsrLogLevel($level));
+    }
+
+    /**
+     * @return Generator<string, array{string, Src\Log\LogLevel}>
+     */
+    public static function fromNameReturnsLogLevelFromGivenNameDataProvider(): Generator
+    {
+        yield 'emergency' => ['emergency', Src\Log\LogLevel::Emergency];
+        yield 'alert' => ['alert', Src\Log\LogLevel::Alert];
+        yield 'critical' => ['critical', Src\Log\LogLevel::Critical];
+        yield 'error' => ['error', Src\Log\LogLevel::Error];
+        yield 'warning' => ['warning', Src\Log\LogLevel::Warning];
+        yield 'notice' => ['notice', Src\Log\LogLevel::Notice];
+        yield 'info' => ['info', Src\Log\LogLevel::Info];
+        yield 'debug' => ['debug', Src\Log\LogLevel::Debug];
+    }
+
+    /**
+     * @return Generator<string, array{Log\LogLevel::*, Src\Log\LogLevel}>
+     */
+    public static function fromPsrLogLevelReturnsLogLevelFromGivenPsrLogLevelDataProvider(): Generator
+    {
+        yield 'emergency' => [Log\LogLevel::EMERGENCY, Src\Log\LogLevel::Emergency];
+        yield 'alert' => [Log\LogLevel::ALERT, Src\Log\LogLevel::Alert];
+        yield 'critical' => [Log\LogLevel::CRITICAL, Src\Log\LogLevel::Critical];
+        yield 'error' => [Log\LogLevel::ERROR, Src\Log\LogLevel::Error];
+        yield 'warning' => [Log\LogLevel::WARNING, Src\Log\LogLevel::Warning];
+        yield 'notice' => [Log\LogLevel::NOTICE, Src\Log\LogLevel::Notice];
+        yield 'info' => [Log\LogLevel::INFO, Src\Log\LogLevel::Info];
+        yield 'debug' => [Log\LogLevel::DEBUG, Src\Log\LogLevel::Debug];
+    }
+}


### PR DESCRIPTION
This PR integrates logging into the cache warmup process. It uses the PSR-3 logger interface and already comes with a basic `FileLogger`. However, any other loggers can be used, as long as they implement the PSR-3 `LoggerInterface`.

The new `LogHandler` takes care of logging each crawling result, depending on a configured log level. It is already used in the default crawlers and gets activated once a concrete logger is injected using the `setLogger()` method (this is also properly handled by the `CrawlerFactory`). In order to mark crawlers as logging-aware, the new `LoggingCrawlerInterface` must be implemented.

On command-line, logging can be activated by passing the `--log-file` command option. It is also possible to configure the log level using the `--log-level` command option (defaults to `error`).

Related: #270