### PR TITLE
[TASK] Add PHPUnit's #[CoversClass()] attribute to all tests

### DIFF
--- a/tests/Unit/CacheWarmerTest.php
+++ b/tests/Unit/CacheWarmerTest.php
@@ -41,6 +41,7 @@ use function sprintf;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(CacheWarmer::class)]
 final class CacheWarmerTest extends Framework\TestCase
 {
     use CacheWarmupResultProcessorTrait;

--- a/tests/Unit/Command/CacheWarmupCommandTest.php
+++ b/tests/Unit/Command/CacheWarmupCommandTest.php
@@ -42,6 +42,7 @@ use function implode;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Command\CacheWarmupCommand::class)]
 final class CacheWarmupCommandTest extends Framework\TestCase
 {
     use Tests\Unit\ClientMockTrait;

--- a/tests/Unit/Crawler/AbstractConfigurableCrawlerTest.php
+++ b/tests/Unit/Crawler/AbstractConfigurableCrawlerTest.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Tests\Unit\Crawler;
 
+use EliasHaeussler\CacheWarmup\Crawler;
 use EliasHaeussler\CacheWarmup\Exception;
 use PHPUnit\Framework;
 
@@ -32,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\AbstractConfigurableCrawler::class)]
 final class AbstractConfigurableCrawlerTest extends Framework\TestCase
 {
     private DummyConfigurableCrawler $subject;

--- a/tests/Unit/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/Unit/Crawler/ConcurrentCrawlerTest.php
@@ -37,6 +37,7 @@ use Psr\Http\Message;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\ConcurrentCrawler::class)]
 final class ConcurrentCrawlerTest extends Framework\TestCase
 {
     use Tests\Unit\CacheWarmupResultProcessorTrait;

--- a/tests/Unit/Crawler/CrawlerFactoryTest.php
+++ b/tests/Unit/Crawler/CrawlerFactoryTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\CrawlerFactory::class)]
 final class CrawlerFactoryTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;

--- a/tests/Unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/Unit/Crawler/OutputtingCrawlerTest.php
@@ -38,6 +38,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\OutputtingCrawler::class)]
 final class OutputtingCrawlerTest extends Framework\TestCase
 {
     use Tests\Unit\CacheWarmupResultProcessorTrait;

--- a/tests/Unit/Crawler/Strategy/SortByChangeFrequencyStrategyTest.php
+++ b/tests/Unit/Crawler/Strategy/SortByChangeFrequencyStrategyTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\Strategy\SortByChangeFrequencyStrategy::class)]
 final class SortByChangeFrequencyStrategyTest extends Framework\TestCase
 {
     private Crawler\Strategy\SortByChangeFrequencyStrategy $subject;

--- a/tests/Unit/Crawler/Strategy/SortByLastModificationDateStrategyTest.php
+++ b/tests/Unit/Crawler/Strategy/SortByLastModificationDateStrategyTest.php
@@ -34,6 +34,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\Strategy\SortByLastModificationDateStrategy::class)]
 final class SortByLastModificationDateStrategyTest extends Framework\TestCase
 {
     private Crawler\Strategy\SortByLastModificationDateStrategy $subject;

--- a/tests/Unit/Crawler/Strategy/SortByPriorityStrategyTest.php
+++ b/tests/Unit/Crawler/Strategy/SortByPriorityStrategyTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Crawler\Strategy\SortByPriorityStrategy::class)]
 final class SortByPriorityStrategyTest extends Framework\TestCase
 {
     private Crawler\Strategy\SortByPriorityStrategy $subject;

--- a/tests/Unit/Exception/InvalidCrawlerExceptionTest.php
+++ b/tests/Unit/Exception/InvalidCrawlerExceptionTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Exception\InvalidCrawlerException::class)]
 final class InvalidCrawlerExceptionTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
+++ b/tests/Unit/Exception/InvalidCrawlerOptionExceptionTest.php
@@ -35,6 +35,7 @@ use function sprintf;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Exception\InvalidCrawlerOptionException::class)]
 final class InvalidCrawlerOptionExceptionTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Exception/InvalidSitemapExceptionTest.php
+++ b/tests/Unit/Exception/InvalidSitemapExceptionTest.php
@@ -38,6 +38,7 @@ use function sprintf;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Exception\InvalidSitemapException::class)]
 final class InvalidSitemapExceptionTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Exception/InvalidUrlExceptionTest.php
+++ b/tests/Unit/Exception/InvalidUrlExceptionTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Exception\InvalidUrlException::class)]
 final class InvalidUrlExceptionTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Exception/MalformedXmlExceptionTest.php
+++ b/tests/Unit/Exception/MalformedXmlExceptionTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Exception\MalformedXmlException::class)]
 final class MalformedXmlExceptionTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Exception/UnsupportedFormatterExceptionTest.php
+++ b/tests/Unit/Exception/UnsupportedFormatterExceptionTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Exception\UnsupportedFormatterException::class)]
 final class UnsupportedFormatterExceptionTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Formatter/FormatterFactoryTest.php
+++ b/tests/Unit/Formatter/FormatterFactoryTest.php
@@ -34,6 +34,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Formatter\FormatterFactory::class)]
 final class FormatterFactoryTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;

--- a/tests/Unit/Formatter/JsonFormatterTest.php
+++ b/tests/Unit/Formatter/JsonFormatterTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Formatter\JsonFormatter::class)]
 final class JsonFormatterTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;

--- a/tests/Unit/Formatter/TextFormatterTest.php
+++ b/tests/Unit/Formatter/TextFormatterTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Formatter\TextFormatter::class)]
 final class TextFormatterTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;

--- a/tests/Unit/Helper/ArrayHelperTest.php
+++ b/tests/Unit/Helper/ArrayHelperTest.php
@@ -32,6 +32,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Src\Helper\ArrayHelper::class)]
 final class ArrayHelperTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Helper/ConsoleHelperTest.php
+++ b/tests/Unit/Helper/ConsoleHelperTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Helper\ConsoleHelper::class)]
 final class ConsoleHelperTest extends Framework\TestCase
 {
     private Console\Formatter\OutputFormatter $formatter;

--- a/tests/Unit/Http/Message/Handler/CompactProgressHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/CompactProgressHandlerTest.php
@@ -35,6 +35,7 @@ use Symfony\Component\Console;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Http\Message\Handler\CompactProgressHandler::class)]
 final class CompactProgressHandlerTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;

--- a/tests/Unit/Http/Message/Handler/ResultCollectorHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/ResultCollectorHandlerTest.php
@@ -35,6 +35,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Http\Message\Handler\ResultCollectorHandler::class)]
 final class ResultCollectorHandlerTest extends Framework\TestCase
 {
     private Http\Message\Handler\ResultCollectorHandler $subject;

--- a/tests/Unit/Http/Message/Handler/VerboseProgressHandlerTest.php
+++ b/tests/Unit/Http/Message/Handler/VerboseProgressHandlerTest.php
@@ -35,6 +35,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Http\Message\Handler\VerboseProgressHandler::class)]
 final class VerboseProgressHandlerTest extends Framework\TestCase
 {
     private Tests\Unit\BufferedConsoleOutput $output;

--- a/tests/Unit/Http/Message/RequestPoolFactoryTest.php
+++ b/tests/Unit/Http/Message/RequestPoolFactoryTest.php
@@ -37,6 +37,7 @@ use function sort;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Http\Message\RequestPoolFactory::class)]
 final class RequestPoolFactoryTest extends Framework\TestCase
 {
     use Tests\Unit\ClientMockTrait;

--- a/tests/Unit/Mapper/Source/XmlSourceTest.php
+++ b/tests/Unit/Mapper/Source/XmlSourceTest.php
@@ -37,6 +37,7 @@ use function iterator_to_array;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Mapper\Source\XmlSource::class)]
 final class XmlSourceTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Result/CacheWarmupResultTest.php
+++ b/tests/Unit/Result/CacheWarmupResultTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Result\CacheWarmupResult::class)]
 final class CacheWarmupResultTest extends Framework\TestCase
 {
     private Result\CacheWarmupResult $subject;

--- a/tests/Unit/Result/CrawlingResultTest.php
+++ b/tests/Unit/Result/CrawlingResultTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Result\CrawlingResult::class)]
 final class CrawlingResultTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Result/ParserResultTest.php
+++ b/tests/Unit/Result/ParserResultTest.php
@@ -34,6 +34,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Result\ParserResult::class)]
 final class ParserResultTest extends Framework\TestCase
 {
     private Result\ParserResult $subject;

--- a/tests/Unit/Sitemap/SitemapTest.php
+++ b/tests/Unit/Sitemap/SitemapTest.php
@@ -35,6 +35,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Sitemap\Sitemap::class)]
 final class SitemapTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Sitemap/UrlTest.php
+++ b/tests/Unit/Sitemap/UrlTest.php
@@ -35,6 +35,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Sitemap\Url::class)]
 final class UrlTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Time/DurationTest.php
+++ b/tests/Unit/Time/DurationTest.php
@@ -33,6 +33,7 @@ use PHPUnit\Framework;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Time\Duration::class)]
 final class DurationTest extends Framework\TestCase
 {
     #[Framework\Attributes\Test]

--- a/tests/Unit/Time/TimeTrackerTest.php
+++ b/tests/Unit/Time/TimeTrackerTest.php
@@ -35,6 +35,7 @@ use function sleep;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Time\TimeTracker::class)]
 final class TimeTrackerTest extends Framework\TestCase
 {
     private Time\TimeTracker $subject;

--- a/tests/Unit/Xml/XmlParserTest.php
+++ b/tests/Unit/Xml/XmlParserTest.php
@@ -39,6 +39,7 @@ use function implode;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
+#[Framework\Attributes\CoversClass(Xml\XmlParser::class)]
 final class XmlParserTest extends Framework\TestCase
 {
     use Tests\Unit\ClientMockTrait;


### PR DESCRIPTION
This PR adds PHPUnit's `#[CoversClass()]` attribute to all tests. With the annotation in place, only the configured class is taken into account for code coverage.