### PR TITLE
[TASK] Rely on PSR log level

### DIFF
--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -24,11 +24,10 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
 use EliasHaeussler\CacheWarmup\Http;
-use EliasHaeussler\CacheWarmup\Log;
 use EliasHaeussler\CacheWarmup\Result;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log;
 
 /**
  * ConcurrentCrawler.
@@ -57,8 +56,12 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
     ];
 
     private readonly ClientInterface $client;
-    private ?LoggerInterface $logger = null;
-    private Log\LogLevel $logLevel = Log\LogLevel::Error;
+    private ?Log\LoggerInterface $logger = null;
+
+    /**
+     * @phpstan-var Log\LogLevel::*
+     */
+    private string $logLevel = Log\LogLevel::ERROR;
 
     public function __construct(
         array $options = [],
@@ -85,12 +88,12 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
         return $resultHandler->getResult();
     }
 
-    public function setLogger(LoggerInterface $logger): void
+    public function setLogger(Log\LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
-    public function setLogLevel(Log\LogLevel $logLevel): void
+    public function setLogLevel(string $logLevel): void
     {
         $this->logLevel = $logLevel;
     }

--- a/src/Crawler/CrawlerFactory.php
+++ b/src/Crawler/CrawlerFactory.php
@@ -24,9 +24,8 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
 use EliasHaeussler\CacheWarmup\Exception;
-use EliasHaeussler\CacheWarmup\Log;
 use JsonException;
-use Psr\Log\LoggerInterface;
+use Psr\Log;
 use Symfony\Component\Console;
 
 use function class_exists;
@@ -42,10 +41,13 @@ use function json_decode;
  */
 final class CrawlerFactory
 {
+    /**
+     * @phpstan-param Log\LogLevel::* $logLevel
+     */
     public function __construct(
         private readonly Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
-        private readonly ?LoggerInterface $logger = null,
-        private readonly Log\LogLevel $logLevel = Log\LogLevel::Error,
+        private readonly ?Log\LoggerInterface $logger = null,
+        private readonly string $logLevel = Log\LogLevel::ERROR,
     ) {
     }
 

--- a/src/Crawler/LoggingCrawlerInterface.php
+++ b/src/Crawler/LoggingCrawlerInterface.php
@@ -23,8 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
-use EliasHaeussler\CacheWarmup\Log;
-use Psr\Log\LoggerInterface;
+use Psr\Log;
 
 /**
  * LoggingCrawlerInterface.
@@ -34,7 +33,10 @@ use Psr\Log\LoggerInterface;
  */
 interface LoggingCrawlerInterface extends CrawlerInterface
 {
-    public function setLogger(LoggerInterface $logger): void;
+    public function setLogger(Log\LoggerInterface $logger): void;
 
-    public function setLogLevel(Log\LogLevel $logLevel): void;
+    /**
+     * @phpstan-param Log\LogLevel::* $logLevel
+     */
+    public function setLogLevel(string $logLevel): void;
 }

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -24,11 +24,10 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
 use EliasHaeussler\CacheWarmup\Http;
-use EliasHaeussler\CacheWarmup\Log;
 use EliasHaeussler\CacheWarmup\Result;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use Psr\Log\LoggerInterface;
+use Psr\Log;
 use Symfony\Component\Console;
 
 use function count;
@@ -61,8 +60,12 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
 
     private readonly ClientInterface $client;
     private Console\Output\OutputInterface $output;
-    private ?LoggerInterface $logger = null;
-    private Log\LogLevel $logLevel = Log\LogLevel::Error;
+    private ?Log\LoggerInterface $logger = null;
+
+    /**
+     * @phpstan-var Log\LogLevel::*
+     */
+    private string $logLevel = Log\LogLevel::ERROR;
 
     public function __construct(
         array $options = [],
@@ -111,12 +114,12 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
         $this->output = $output;
     }
 
-    public function setLogger(LoggerInterface $logger): void
+    public function setLogger(Log\LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
-    public function setLogLevel(Log\LogLevel $logLevel): void
+    public function setLogLevel(string $logLevel): void
     {
         $this->logLevel = $logLevel;
     }

--- a/src/Http/Message/Handler/LogHandler.php
+++ b/src/Http/Message/Handler/LogHandler.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Http\Message\Handler;
 use EliasHaeussler\CacheWarmup\Log;
 use Psr\Http\Message;
 use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use Throwable;
 
 /**
@@ -37,17 +38,17 @@ use Throwable;
 final class LogHandler implements ResponseHandlerInterface
 {
     /**
-     * @phpstan-param Log\LogLevel::* $logLevel
+     * @phpstan-param LogLevel::* $logLevel
      */
     public function __construct(
         private readonly LoggerInterface $logger,
-        private readonly Log\LogLevel $logLevel = Log\LogLevel::Error,
+        private readonly string $logLevel = LogLevel::ERROR,
     ) {
     }
 
     public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void
     {
-        if ($this->logLevel->satisfies(Log\LogLevel::Info)) {
+        if (Log\LogLevel::satisfies($this->logLevel, LogLevel::INFO)) {
             $this->logger->info(
                 'URL {url} was successfully crawled (status code: {status_code}).',
                 [
@@ -60,7 +61,7 @@ final class LogHandler implements ResponseHandlerInterface
 
     public function onFailure(Throwable $exception, Message\UriInterface $uri): void
     {
-        if ($this->logLevel->satisfies(Log\LogLevel::Error)) {
+        if (Log\LogLevel::satisfies($this->logLevel, LogLevel::ERROR)) {
             $this->logger->error(
                 'Error while crawling URL {url} (exception: {exception}).',
                 [

--- a/src/Log/FileLogger.php
+++ b/src/Log/FileLogger.php
@@ -74,8 +74,7 @@ final class FileLogger extends Log\AbstractLogger
             $this->stream = $this->openStream();
         }
 
-        $logLevel = LogLevel::fromPsrLogLevel($level);
-        $formatted = $this->formatter->format($logLevel, $message, $context);
+        $formatted = $this->formatter->format($level, $message, $context);
 
         fwrite($this->stream, $formatted.PHP_EOL);
     }

--- a/src/Log/Formatter/CompactLogFormatter.php
+++ b/src/Log/Formatter/CompactLogFormatter.php
@@ -25,7 +25,6 @@ namespace EliasHaeussler\CacheWarmup\Log\Formatter;
 
 use DateTimeImmutable;
 use DateTimeInterface;
-use EliasHaeussler\CacheWarmup\Log;
 use JsonSerializable;
 use Stringable;
 
@@ -46,7 +45,7 @@ final class CompactLogFormatter implements LogFormatter
 {
     private const TEMPLATE = '[%s] %s: %s %s';
 
-    public function format(Log\LogLevel $level, Stringable|string $message, array $context = []): string
+    public function format(string $level, Stringable|string $message, array $context = []): string
     {
         $date = new DateTimeImmutable();
         $formattedMessage = $this->formatMessage($message, $context);
@@ -55,7 +54,7 @@ final class CompactLogFormatter implements LogFormatter
         return sprintf(
             self::TEMPLATE,
             $date->format(DateTimeInterface::ATOM),
-            strtoupper($level->name),
+            strtoupper($level),
             $formattedMessage,
             json_encode($context),
         );

--- a/src/Log/Formatter/LogFormatter.php
+++ b/src/Log/Formatter/LogFormatter.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Log\Formatter;
 
-use EliasHaeussler\CacheWarmup\Log;
+use Psr\Log;
 use Stringable;
 
 /**
@@ -35,7 +35,9 @@ use Stringable;
 interface LogFormatter
 {
     /**
+     * @phpstan-param Log\LogLevel::* $level
+     *
      * @param array<string, mixed> $context
      */
-    public function format(Log\LogLevel $level, Stringable|string $message, array $context = []): string;
+    public function format(string $level, Stringable|string $message, array $context = []): string;
 }

--- a/src/Log/LogLevel.php
+++ b/src/Log/LogLevel.php
@@ -23,10 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Log;
 
-use EliasHaeussler\CacheWarmup\Exception;
 use Psr\Log;
-
-use function strtolower;
 
 /**
  * LogLevel.
@@ -34,54 +31,42 @@ use function strtolower;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-enum LogLevel: int
+final class LogLevel extends Log\LogLevel
 {
-    case Emergency = 7;
-    case Alert = 6;
-    case Critical = 5;
-    case Error = 4;
-    case Warning = 3;
-    case Notice = 2;
-    case Info = 1;
-    case Debug = 0;
+    private const VALUE_MAP = [
+        Log\LogLevel::EMERGENCY => 7,
+        Log\LogLevel::ALERT => 6,
+        Log\LogLevel::CRITICAL => 5,
+        Log\LogLevel::ERROR => 4,
+        Log\LogLevel::WARNING => 3,
+        Log\LogLevel::NOTICE => 2,
+        Log\LogLevel::INFO => 1,
+        Log\LogLevel::DEBUG => 0,
+    ];
 
-    public function satisfies(self $other): bool
+    /**
+     * @phpstan-param Log\LogLevel::* $level
+     * @phpstan-param Log\LogLevel::* $other
+     */
+    public static function satisfies(string $level, string $other): bool
     {
-        return $this->value <= $other->value;
+        return self::VALUE_MAP[$level] <= self::VALUE_MAP[$other];
     }
 
     /**
-     * @throws Exception\UnsupportedLogLevelException
+     * @return array<Log\LogLevel::*>
      */
-    public static function fromName(string $level): self
+    public static function getAll(): array
     {
-        return match (strtolower($level)) {
-            'emergency' => self::Emergency,
-            'alert' => self::Alert,
-            'critical' => self::Critical,
-            'error' => self::Error,
-            'warning' => self::Warning,
-            'notice' => self::Notice,
-            'info' => self::Info,
-            'debug' => self::Debug,
-            default => throw Exception\UnsupportedLogLevelException::create($level),
-        };
-    }
-
-    /**
-     * @phpstan-param Log\LogLevel::* $psrLogLevel
-     */
-    public static function fromPsrLogLevel(string $psrLogLevel): self
-    {
-        return match ($psrLogLevel) {
-            Log\LogLevel::EMERGENCY => self::Emergency,
-            Log\LogLevel::ALERT => self::Alert,
-            Log\LogLevel::CRITICAL => self::Critical,
-            Log\LogLevel::ERROR => self::Error,
-            Log\LogLevel::WARNING => self::Warning,
-            Log\LogLevel::NOTICE => self::Notice,
-            Log\LogLevel::INFO => self::Info,
-            Log\LogLevel::DEBUG => self::Debug,
-        };
+        return [
+            Log\LogLevel::EMERGENCY,
+            Log\LogLevel::ALERT,
+            Log\LogLevel::CRITICAL,
+            Log\LogLevel::ERROR,
+            Log\LogLevel::WARNING,
+            Log\LogLevel::NOTICE,
+            Log\LogLevel::INFO,
+            Log\LogLevel::DEBUG,
+        ];
     }
 }

--- a/tests/src/Command/CacheWarmupCommandTest.php
+++ b/tests/src/Command/CacheWarmupCommandTest.php
@@ -68,6 +68,14 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function initializeThrowsExceptionIfGivenLogLevelIsUnsupported(): void
+    {
+        $this->expectExceptionObject(Src\Exception\UnsupportedLogLevelException::create('foo'));
+
+        $this->commandTester->execute(['--log-level' => 'foo']);
+    }
+
+    #[Framework\Attributes\Test]
     public function initializeHidesOutputForCrawlersIfGivenFormatterIsNotVerbose(): void
     {
         $this->mockSitemapRequest('valid_sitemap_3');

--- a/tests/src/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/src/Crawler/ConcurrentCrawlerTest.php
@@ -29,6 +29,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 use Psr\Http\Message;
+use Psr\Log;
 
 /**
  * ConcurrentCrawlerTest.
@@ -201,10 +202,10 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
         $uri2 = new Psr7\Uri('https://www.foo.baz');
 
         $this->subject->setLogger($logger);
-        $this->subject->setLogLevel(Src\Log\LogLevel::Info);
+        $this->subject->setLogLevel(Log\LogLevel::INFO);
         $this->subject->crawl([$uri1, $uri2]);
 
-        self::assertCount(1, $logger->log[Src\Log\LogLevel::Error->value]);
-        self::assertCount(1, $logger->log[Src\Log\LogLevel::Info->value]);
+        self::assertCount(1, $logger->log[Log\LogLevel::ERROR]);
+        self::assertCount(1, $logger->log[Log\LogLevel::INFO]);
     }
 }

--- a/tests/src/Crawler/CrawlerFactoryTest.php
+++ b/tests/src/Crawler/CrawlerFactoryTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
 
 use EliasHaeussler\CacheWarmup as Src;
 use PHPUnit\Framework;
+use Psr\Log;
 use Symfony\Component\Console;
 
 /**
@@ -102,7 +103,7 @@ final class CrawlerFactoryTest extends Framework\TestCase
 
         self::assertInstanceOf(DummyLoggingCrawler::class, $actual);
         self::assertSame($this->logger, DummyLoggingCrawler::$logger);
-        self::assertSame(Src\Log\LogLevel::Error, DummyLoggingCrawler::$logLevel);
+        self::assertSame(Log\LogLevel::ERROR, DummyLoggingCrawler::$logLevel);
 
         DummyLoggingCrawler::$logger = null;
         DummyLoggingCrawler::$logLevel = null;

--- a/tests/src/Crawler/DummyLoggingCrawler.php
+++ b/tests/src/Crawler/DummyLoggingCrawler.php
@@ -24,8 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
 
 use EliasHaeussler\CacheWarmup\Crawler;
-use EliasHaeussler\CacheWarmup\Log;
-use Psr\Log\LoggerInterface;
+use Psr\Log;
 
 /**
  * DummyLoggingCrawler.
@@ -37,15 +36,19 @@ use Psr\Log\LoggerInterface;
  */
 final class DummyLoggingCrawler extends DummyCrawler implements Crawler\LoggingCrawlerInterface
 {
-    public static ?LoggerInterface $logger = null;
-    public static ?Log\LogLevel $logLevel = null;
+    public static ?Log\LoggerInterface $logger = null;
 
-    public function setLogger(LoggerInterface $logger): void
+    /**
+     * @phpstan-var Log\LogLevel::*|null
+     */
+    public static ?string $logLevel = null;
+
+    public function setLogger(Log\LoggerInterface $logger): void
     {
         self::$logger = $logger;
     }
 
-    public function setLogLevel(Log\LogLevel $logLevel): void
+    public function setLogLevel(string $logLevel): void
     {
         self::$logLevel = $logLevel;
     }

--- a/tests/src/Crawler/OutputtingCrawlerTest.php
+++ b/tests/src/Crawler/OutputtingCrawlerTest.php
@@ -29,6 +29,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
 use Psr\Http\Message;
+use Psr\Log;
 use Symfony\Component\Console;
 
 /**
@@ -252,10 +253,10 @@ final class OutputtingCrawlerTest extends Framework\TestCase
         $uri2 = new Psr7\Uri('https://www.foo.baz');
 
         $this->subject->setLogger($logger);
-        $this->subject->setLogLevel(Src\Log\LogLevel::Info);
+        $this->subject->setLogLevel(Log\LogLevel::INFO);
         $this->subject->crawl([$uri1, $uri2]);
 
-        self::assertCount(1, $logger->log[Src\Log\LogLevel::Error->value]);
-        self::assertCount(1, $logger->log[Src\Log\LogLevel::Info->value]);
+        self::assertCount(1, $logger->log[Log\LogLevel::ERROR]);
+        self::assertCount(1, $logger->log[Log\LogLevel::INFO]);
     }
 }

--- a/tests/src/Http/Message/Handler/LogHandlerTest.php
+++ b/tests/src/Http/Message/Handler/LogHandlerTest.php
@@ -28,6 +28,7 @@ use EliasHaeussler\CacheWarmup\Tests;
 use Exception;
 use GuzzleHttp\Psr7;
 use PHPUnit\Framework;
+use Psr\Log;
 
 /**
  * LogHandlerTest.
@@ -55,7 +56,7 @@ final class LogHandlerTest extends Framework\TestCase
             new Psr7\Uri('https://www.example.com'),
         );
 
-        self::assertSame([], $this->logger->log[Src\Log\LogLevel::Info->value]);
+        self::assertSame([], $this->logger->log[Log\LogLevel::INFO]);
     }
 
     #[Framework\Attributes\Test]
@@ -71,27 +72,27 @@ final class LogHandlerTest extends Framework\TestCase
             ],
         ];
 
-        $subject = new Src\Http\Message\Handler\LogHandler($this->logger, Src\Log\LogLevel::Info);
+        $subject = new Src\Http\Message\Handler\LogHandler($this->logger, Log\LogLevel::INFO);
 
         $subject->onSuccess(
             new Psr7\Response(),
             new Psr7\Uri('https://www.example.com'),
         );
 
-        self::assertSame($expected, $this->logger->log[Src\Log\LogLevel::Info->value]);
+        self::assertSame($expected, $this->logger->log[Log\LogLevel::INFO]);
     }
 
     #[Framework\Attributes\Test]
     public function onFailureDoesNothingIfConfiguredLogLevelDoesNotSatisfyErrorLevel(): void
     {
-        $subject = new Src\Http\Message\Handler\LogHandler($this->logger, Src\Log\LogLevel::Emergency);
+        $subject = new Src\Http\Message\Handler\LogHandler($this->logger, Log\LogLevel::EMERGENCY);
 
         $subject->onFailure(
             new Exception(),
             new Psr7\Uri('https://www.example.com'),
         );
 
-        self::assertSame([], $this->logger->log[Src\Log\LogLevel::Info->value]);
+        self::assertSame([], $this->logger->log[Log\LogLevel::INFO]);
     }
 
     #[Framework\Attributes\Test]
@@ -112,6 +113,6 @@ final class LogHandlerTest extends Framework\TestCase
             new Psr7\Uri('https://www.example.com'),
         );
 
-        self::assertSame($expected, $this->logger->log[Src\Log\LogLevel::Error->value]);
+        self::assertSame($expected, $this->logger->log[Log\LogLevel::ERROR]);
     }
 }

--- a/tests/src/Log/DummyLogger.php
+++ b/tests/src/Log/DummyLogger.php
@@ -39,14 +39,14 @@ use Stringable;
 final class DummyLogger extends AbstractLogger
 {
     /**
-     * @var array<value-of<Log\LogLevel>, list<array{message: string|Stringable, context: array<string, mixed>}>>
+     * @var array<LogLevel::*, list<array{message: string|Stringable, context: array<string, mixed>}>>
      */
     public array $log = [];
 
     public function __construct()
     {
-        foreach (Log\LogLevel::cases() as $logLevel) {
-            $this->log[$logLevel->value] = [];
+        foreach (Log\LogLevel::getAll() as $logLevel) {
+            $this->log[$logLevel] = [];
         }
     }
 
@@ -57,9 +57,7 @@ final class DummyLogger extends AbstractLogger
      */
     public function log($level, Stringable|string $message, array $context = []): void
     {
-        $logLevel = Log\LogLevel::fromPsrLogLevel($level);
-
-        $this->log[$logLevel->value][] = [
+        $this->log[$level][] = [
             'message' => $message,
             'context' => $context,
         ];

--- a/tests/src/Log/Formatter/CompactLogFormatterTest.php
+++ b/tests/src/Log/Formatter/CompactLogFormatterTest.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Log\Formatter;
 
 use EliasHaeussler\CacheWarmup as Src;
 use PHPUnit\Framework;
+use Psr\Log;
 use stdClass;
 
 /**
@@ -52,7 +53,7 @@ final class CompactLogFormatterTest extends Framework\TestCase
 
         self::assertStringEndsWith(
             'ERROR: oops, a baz occurred. []',
-            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.', $context),
+            $this->subject->format(Log\LogLevel::ERROR, 'oops, a {foo} occurred.', $context),
         );
     }
 
@@ -66,7 +67,7 @@ final class CompactLogFormatterTest extends Framework\TestCase
 
         self::assertStringEndsWith(
             'ERROR: oops, a baz occurred. {"baz":"foo"}',
-            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.', $context),
+            $this->subject->format(Log\LogLevel::ERROR, 'oops, a {foo} occurred.', $context),
         );
     }
 
@@ -79,7 +80,7 @@ final class CompactLogFormatterTest extends Framework\TestCase
 
         self::assertStringEndsWith(
             'ERROR: oops, a {foo} occurred. {"foo":"stdClass"}',
-            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.', $context),
+            $this->subject->format(Log\LogLevel::ERROR, 'oops, a {foo} occurred.', $context),
         );
     }
 
@@ -88,7 +89,7 @@ final class CompactLogFormatterTest extends Framework\TestCase
     {
         self::assertStringEndsWith(
             'ERROR: oops, a {foo} occurred. []',
-            $this->subject->format(Src\Log\LogLevel::Error, 'oops, a {foo} occurred.'),
+            $this->subject->format(Log\LogLevel::ERROR, 'oops, a {foo} occurred.'),
         );
     }
 }

--- a/tests/src/Log/LogLevelTest.php
+++ b/tests/src/Log/LogLevelTest.php
@@ -24,7 +24,6 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Log;
 
 use EliasHaeussler\CacheWarmup as Src;
-use Generator;
 use PHPUnit\Framework;
 use Psr\Log;
 
@@ -40,64 +39,26 @@ final class LogLevelTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function satisfiesReturnsTrueIfLogLevelSatisfiesGivenLogLevel(): void
     {
-        $subject = Src\Log\LogLevel::Warning;
+        $level = Log\LogLevel::WARNING;
 
-        self::assertTrue($subject->satisfies(Src\Log\LogLevel::Error));
-        self::assertFalse($subject->satisfies(Src\Log\LogLevel::Notice));
+        self::assertTrue(Src\Log\LogLevel::satisfies($level, Log\LogLevel::ERROR));
+        self::assertFalse(Src\Log\LogLevel::satisfies($level, Log\LogLevel::NOTICE));
     }
 
     #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('fromNameReturnsLogLevelFromGivenNameDataProvider')]
-    public function fromNameReturnsLogLevelFromGivenName(string $level, Src\Log\LogLevel $expected): void
+    public function getAllReturnsAllAvailableLogLevels(): void
     {
-        self::assertSame($expected, Src\Log\LogLevel::fromName($level));
-    }
+        $expected = [
+            Log\LogLevel::EMERGENCY,
+            Log\LogLevel::ALERT,
+            Log\LogLevel::CRITICAL,
+            Log\LogLevel::ERROR,
+            Log\LogLevel::WARNING,
+            Log\LogLevel::NOTICE,
+            Log\LogLevel::INFO,
+            Log\LogLevel::DEBUG,
+        ];
 
-    #[Framework\Attributes\Test]
-    public function fromNameThrowsExceptionOnUnsupportedLogLevel(): void
-    {
-        $this->expectExceptionObject(Src\Exception\UnsupportedLogLevelException::create('foo'));
-
-        Src\Log\LogLevel::fromName('foo');
-    }
-
-    /**
-     * @phpstan-param Log\LogLevel::* $level
-     */
-    #[Framework\Attributes\Test]
-    #[Framework\Attributes\DataProvider('fromPsrLogLevelReturnsLogLevelFromGivenPsrLogLevelDataProvider')]
-    public function fromPsrLogLevelReturnsLogLevelFromGivenPsrLogLevel(string $level, Src\Log\LogLevel $expected): void
-    {
-        self::assertSame($expected, Src\Log\LogLevel::fromPsrLogLevel($level));
-    }
-
-    /**
-     * @return Generator<string, array{string, Src\Log\LogLevel}>
-     */
-    public static function fromNameReturnsLogLevelFromGivenNameDataProvider(): Generator
-    {
-        yield 'emergency' => ['emergency', Src\Log\LogLevel::Emergency];
-        yield 'alert' => ['alert', Src\Log\LogLevel::Alert];
-        yield 'critical' => ['critical', Src\Log\LogLevel::Critical];
-        yield 'error' => ['error', Src\Log\LogLevel::Error];
-        yield 'warning' => ['warning', Src\Log\LogLevel::Warning];
-        yield 'notice' => ['notice', Src\Log\LogLevel::Notice];
-        yield 'info' => ['info', Src\Log\LogLevel::Info];
-        yield 'debug' => ['debug', Src\Log\LogLevel::Debug];
-    }
-
-    /**
-     * @return Generator<string, array{Log\LogLevel::*, Src\Log\LogLevel}>
-     */
-    public static function fromPsrLogLevelReturnsLogLevelFromGivenPsrLogLevelDataProvider(): Generator
-    {
-        yield 'emergency' => [Log\LogLevel::EMERGENCY, Src\Log\LogLevel::Emergency];
-        yield 'alert' => [Log\LogLevel::ALERT, Src\Log\LogLevel::Alert];
-        yield 'critical' => [Log\LogLevel::CRITICAL, Src\Log\LogLevel::Critical];
-        yield 'error' => [Log\LogLevel::ERROR, Src\Log\LogLevel::Error];
-        yield 'warning' => [Log\LogLevel::WARNING, Src\Log\LogLevel::Warning];
-        yield 'notice' => [Log\LogLevel::NOTICE, Src\Log\LogLevel::Notice];
-        yield 'info' => [Log\LogLevel::INFO, Src\Log\LogLevel::Info];
-        yield 'debug' => [Log\LogLevel::DEBUG, Src\Log\LogLevel::Debug];
+        self::assertSame($expected, Src\Log\LogLevel::getAll());
     }
 }


### PR DESCRIPTION
This PR changes logging behavior to use log levels from the `psr/log` package instead of defining custom log levels with an additional mapping between both classes.