### PR TITLE
[BUGFIX] Pass original uri object within log context

### DIFF
--- a/src/Http/Message/Handler/LogHandler.php
+++ b/src/Http/Message/Handler/LogHandler.php
@@ -52,7 +52,7 @@ final class LogHandler implements ResponseHandlerInterface
             $this->logger->info(
                 'URL {url} was successfully crawled (status code: {status_code}).',
                 [
-                    'url' => (string) $uri,
+                    'url' => $uri,
                     'status_code' => $response->getStatusCode(),
                 ],
             );
@@ -65,7 +65,7 @@ final class LogHandler implements ResponseHandlerInterface
             $this->logger->error(
                 'Error while crawling URL {url} (exception: {exception}).',
                 [
-                    'url' => (string) $uri,
+                    'url' => $uri,
                     'exception' => $exception->getMessage(),
                 ],
             );

--- a/tests/src/Http/Message/Handler/LogHandlerTest.php
+++ b/tests/src/Http/Message/Handler/LogHandlerTest.php
@@ -66,7 +66,7 @@ final class LogHandlerTest extends Framework\TestCase
             [
                 'message' => 'URL {url} was successfully crawled (status code: {status_code}).',
                 'context' => [
-                    'url' => 'https://www.example.com',
+                    'url' => new Psr7\Uri('https://www.example.com'),
                     'status_code' => 200,
                 ],
             ],
@@ -79,7 +79,7 @@ final class LogHandlerTest extends Framework\TestCase
             new Psr7\Uri('https://www.example.com'),
         );
 
-        self::assertSame($expected, $this->logger->log[Log\LogLevel::INFO]);
+        self::assertEquals($expected, $this->logger->log[Log\LogLevel::INFO]);
     }
 
     #[Framework\Attributes\Test]
@@ -102,7 +102,7 @@ final class LogHandlerTest extends Framework\TestCase
             [
                 'message' => 'Error while crawling URL {url} (exception: {exception}).',
                 'context' => [
-                    'url' => 'https://www.example.com',
+                    'url' => new Psr7\Uri('https://www.example.com'),
                     'exception' => 'oops, something went wrong.',
                 ],
             ],
@@ -113,6 +113,6 @@ final class LogHandlerTest extends Framework\TestCase
             new Psr7\Uri('https://www.example.com'),
         );
 
-        self::assertSame($expected, $this->logger->log[Log\LogLevel::ERROR]);
+        self::assertEquals($expected, $this->logger->log[Log\LogLevel::ERROR]);
     }
 }


### PR DESCRIPTION
Since uris are always stringable, they can be formatted properly by the logger. There's no need to pass only the url itself, since the original uri object may contain additional relevant data.