### PR TITLE
[BUGFIX] Pass original exception object within log context

### DIFF
--- a/src/Http/Message/Handler/LogHandler.php
+++ b/src/Http/Message/Handler/LogHandler.php
@@ -66,7 +66,7 @@ final class LogHandler implements ResponseHandlerInterface
                 'Error while crawling URL {url} (exception: {exception}).',
                 [
                     'url' => $uri,
-                    'exception' => $exception->getMessage(),
+                    'exception' => $exception,
                 ],
             );
         }

--- a/tests/src/Http/Message/Handler/LogHandlerTest.php
+++ b/tests/src/Http/Message/Handler/LogHandlerTest.php
@@ -103,7 +103,7 @@ final class LogHandlerTest extends Framework\TestCase
                 'message' => 'Error while crawling URL {url} (exception: {exception}).',
                 'context' => [
                     'url' => new Psr7\Uri('https://www.example.com'),
-                    'exception' => 'oops, something went wrong.',
+                    'exception' => new Exception('oops, something went wrong.'),
                 ],
             ],
         ];


### PR DESCRIPTION
This PR follows the same strategy like #275, but for the failure part: Exceptions are now passed as whole objects to the logger instead of just their message.