### PR TITLE
[TASK] Implicitly enable progress bar with non-verbose formatters

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,9 @@ Show a progress bar during cache warmup.
 > 💡 You can show a more verbose progress bar by increasing output verbosity
 > with the `--verbose` command option.
 
+> ⚠️The progress bar is implicitly enabled when using a non-verbose
+> [formatter](#--format), e.g. `json`.
+
 ```bash
 $ cache-warmup --progress
 ```

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -313,9 +313,14 @@ HELP);
             throw Exception\UnsupportedLogLevelException::create($logLevel);
         }
 
-        // Disable output if formatter is non-verbose
+        // Use error output or disable output if formatter is non-verbose
         if (!$this->formatter->isVerbose()) {
-            $output = new Console\Output\NullOutput();
+            if ($output instanceof Console\Output\ConsoleOutputInterface) {
+                $input->setOption('progress', true);
+                $output = $output->getErrorOutput();
+            } else {
+                $output = new Console\Output\NullOutput();
+            }
         }
 
         $this->crawlerFactory = new Crawler\CrawlerFactory($output, $logger, $logLevel);

--- a/tests/src/Command/CacheWarmupCommandTest.php
+++ b/tests/src/Command/CacheWarmupCommandTest.php
@@ -80,20 +80,34 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     {
         $this->mockSitemapRequest('valid_sitemap_3');
 
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--format' => 'json',
+        ]);
+
+        self::assertSame('', $this->commandTester->getDisplay());
+    }
+
+    #[Framework\Attributes\Test]
+    public function initializeWritesImplicitlyEnablesProgressForErrorOutputIfGivenFormatterIsNotVerbose(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
         $this->commandTester->execute(
             [
                 'sitemaps' => [
                     'https://www.example.com/sitemap.xml',
                 ],
                 '--format' => 'json',
-                '--progress' => true,
             ],
             [
-                'verbosity' => Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE,
+                'capture_stderr_separately' => true,
             ],
         );
 
-        self::assertSame('', $this->commandTester->getDisplay());
+        self::assertStringContainsString('100%', $this->commandTester->getErrorOutput());
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This PR improves UX when using non-verbose formatters such as `json`. It implicitly enables a progress bar and writes it to the error output. This way, users can keep track of the actual warmup progress while dumping the cache warmup result to an external json file.

Related: #261