### PR TITLE
[TASK] Use PHP 8.2 in CI

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer:v2, composer-require-checker, composer-unused:0.7
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer:v2
           coverage: pcov
 
@@ -101,7 +101,7 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: 8.2
           tools: composer:v2,phive
 
       # Compile PHAR

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"armin/editorconfig-cli": "^1.5",
 		"eliashaeussler/php-cs-fixer-config": "^1.0",
 		"eliashaeussler/phpstan-config": "^2.0",
-		"eliashaeussler/rector-config": "^1.1",
+		"eliashaeussler/rector-config": "^1.6",
 		"ergebnis/composer-normalize": "^2.28",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-phpunit": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "49d26c5caa32970ffc09fd445e7a4ff8",
+    "content-hash": "0d8a36a62a24085c540e366ac2e057e3",
     "packages": [
         {
             "name": "cuyz/valinor",

--- a/rector.php
+++ b/rector.php
@@ -23,11 +23,12 @@ declare(strict_types=1);
 
 use EliasHaeussler\RectorConfig\Config\Config;
 use Rector\Config\RectorConfig;
+use Rector\Core\ValueObject\PhpVersion;
 use Rector\Php80\Rector\Class_\AnnotationToAttributeRector;
 use Rector\Privatization\Rector\Class_\FinalizeClassesWithoutChildrenRector;
 
 return static function (RectorConfig $rectorConfig): void {
-    Config::create($rectorConfig)
+    Config::create($rectorConfig, PhpVersion::PHP_81)
         ->in(
             __DIR__.'/src',
             __DIR__.'/tests',


### PR DESCRIPTION
This PR switches from PHP 8.1 to 8.2 as default version in all workflows.