### PR TITLE
[TASK] Use latest version of `composer-unused´ in CGL workflow

### DIFF
--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -22,7 +22,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: 8.2
-          tools: composer:v2, composer-require-checker, composer-unused:0.7
+          tools: composer:v2, composer-require-checker, composer-unused
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR switches back to the latest version of `composer-unused` to be used in CGL workflow.