### PR TITLE
[TASK] Include OCI labels in Docker image

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
 
   # Job: Create release
   release:


### PR DESCRIPTION
This PR references the generated OCI labels when building the Docker image.