### PR TITLE
[FEATURE] Allow local sitemap files to be used for cache warmup

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ The following input parameters are available:
 
 | Input parameter                                 | Description                                                            |
 |-------------------------------------------------|------------------------------------------------------------------------|
-| [`sitemaps`](#sitemaps)                         | URLs of XML sitemaps to be warmed up                                   |
+| [`sitemaps`](#sitemaps)                         | URLs or local filenames of XML sitemaps to be warmed up                |
 | [`--allow-failures`](#--allow-failures)         | Allow failures during URL crawling and exit with zero                  |
 | [`--crawler-options`, `-o`](#--crawler-options) | JSON-encoded string of additional config for configurable crawlers     |
 | [`--crawler`, `-c`](#--crawler)                 | FQCN of the crawler to use for cache warmup                            |
@@ -103,10 +103,10 @@ input parameters.
 
 #### `sitemaps`
 
-URLs of XML sitemaps to be warmed up.
+URLs or local filenames of XML sitemaps to be warmed up.
 
 ```bash
-$ cache-warmup "https://www.example.org/sitemap.xml" "https://www.example.org/de/sitemap.xml"
+$ cache-warmup "https://www.example.org/sitemap.xml" "/var/www/html/sitemap.xml"
 ```
 
 | Shorthand               | –                                                                            |

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -98,7 +98,8 @@ It requires a set of XML sitemaps offering several URLs which will be crawled.
 <info>========</info>
 The list of sitemaps to be crawled can be defined as command argument:
 
-   <comment>%command.full_name% https://www.example.com/sitemap.xml</comment>
+   * <comment>%command.full_name% https://www.example.com/sitemap.xml</comment> (URL)
+   * <comment>%command.full_name% /var/www/html/sitemap.xml</comment> (local file)
 
 You are free to crawl as many sitemaps as you want.
 Alternatively, sitemaps can be specified from user input when application is in interactive mode.
@@ -211,7 +212,7 @@ HELP);
         $this->addArgument(
             'sitemaps',
             Console\Input\InputArgument::OPTIONAL | Console\Input\InputArgument::IS_ARRAY,
-            'URLs of XML sitemaps to be used for cache warming',
+            'URLs or local filenames of XML sitemaps to be used for cache warming',
         );
         $this->addOption(
             'urls',

--- a/src/Exception/FilesystemFailureException.php
+++ b/src/Exception/FilesystemFailureException.php
@@ -45,4 +45,12 @@ final class FilesystemFailureException extends Exception
             1691649034,
         );
     }
+
+    public static function forMissingFile(string $file): self
+    {
+        return new self(
+            sprintf('The file "%s" does not exist or is not readable.', $file),
+            1698427082,
+        );
+    }
 }

--- a/tests/src/CacheWarmerTest.php
+++ b/tests/src/CacheWarmerTest.php
@@ -282,6 +282,9 @@ final class CacheWarmerTest extends Framework\TestCase
         $origin2 = new Src\Sitemap\Sitemap(new Psr7\Uri('https://www.example.com/sitemap.xml'));
         $origin3 = new Src\Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap_en.xml'), origin: $origin2);
 
+        $localFile = __DIR__.'/Fixtures/valid_sitemap_2.xml';
+        $originLocal = new Src\Sitemap\Sitemap(new Psr7\Uri('file://'.$localFile));
+
         yield 'empty sitemaps' => [
             [],
             [],
@@ -379,6 +382,34 @@ final class CacheWarmerTest extends Framework\TestCase
                 'valid_sitemap_1',
                 'valid_sitemap_3',
             ],
+        ];
+        yield 'local sitemap file' => [
+            [
+                $originLocal,
+            ],
+            [
+                $originLocal,
+            ],
+            [
+                new Src\Sitemap\Url('https://www.example.org/', origin: $originLocal),
+                new Src\Sitemap\Url('https://www.example.org/foo', origin: $originLocal),
+                new Src\Sitemap\Url('https://www.example.org/baz', origin: $originLocal),
+            ],
+            [],
+        ];
+        yield 'local sitemap object' => [
+            [
+                $localFile,
+            ],
+            [
+                $originLocal,
+            ],
+            [
+                new Src\Sitemap\Url('https://www.example.org/', origin: $originLocal),
+                new Src\Sitemap\Url('https://www.example.org/foo', origin: $originLocal),
+                new Src\Sitemap\Url('https://www.example.org/baz', origin: $originLocal),
+            ],
+            [],
         ];
     }
 

--- a/tests/src/Exception/FilesystemFailureExceptionTest.php
+++ b/tests/src/Exception/FilesystemFailureExceptionTest.php
@@ -52,4 +52,13 @@ final class FilesystemFailureExceptionTest extends Framework\TestCase
         self::assertSame(1691649034, $actual->getCode());
         self::assertSame('Unable to open a file stream for "foo".', $actual->getMessage());
     }
+
+    #[Framework\Attributes\Test]
+    public function forMissingFileReturnsExceptionForMissingFile(): void
+    {
+        $actual = Src\Exception\FilesystemFailureException::forMissingFile('foo');
+
+        self::assertSame(1698427082, $actual->getCode());
+        self::assertSame('The file "foo" does not exist or is not readable.', $actual->getMessage());
+    }
 }


### PR DESCRIPTION
With this PR, it is now possible to specify local filenames as XML sitemaps to be used for cache warmup.

Example:

```bash
$ cache-warmup.phar /var/www/html/sitemap.xml
```

Internally, local files are resolved to URIs with `file://` schema. In the above example, the XML sitemap resolves to `file:///var/www/html/sitemap.xml`.

Resolves: #297