### PR TITLE
[FEATURE] Introduce stoppable crawler and `--stop-on-failure` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ The following input parameters are available:
 | [`--log-level`](#--log-level)                   | Log level used to determine which crawling results to log              |
 | [`--progress`, `-p`](#--progress)               | Show a progress bar during cache warmup                                |
 | [`--repeat-after`](#--repeat-after)             | Run cache warmup in endless loop and repeat *x* seconds after each run |
+| [`--stop-on-failure`](#--stop-on-failure)       | Cancel further cache warmup requests on failure                        |
 | [`--strategy`, `-s`](#--strategy)               | Optional crawling strategy to prepare URLs before crawling them        |
 | [`--urls`, `-u`](#--urls)                       | Additional URLs to be warmed up                                        |
 
@@ -195,6 +196,9 @@ The crawler must implement one the following interfaces:
   current console output to generate user-oriented output.
 * [`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface`][5] allows to
   make crawlers configurable (see [`--crawler-options`](#--crawler-options)).
+* [`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawlerInterface`][23] may receive
+  an indicator whether to stop cache warmup prematurely if a crawling fails (see
+  [`--stop-on-failure`](#--stop-on-failure)).
 
 ```bash
 $ cache-warmup --crawler "Vendor\Crawler\MyCustomCrawler"
@@ -318,6 +322,20 @@ Allow failures during URL crawling and exit with zero.
 
 ```bash
 $ cache-warmup --allow-failures
+```
+
+| Shorthand               | –      |
+|:------------------------|:-------|
+| Required                | **–**  |
+| Multiple values allowed | **–**  |
+| Default                 | **no** |
+
+#### `--stop-on-failure`
+
+Cancel further cache warmup requests on failure.
+
+```bash
+$ cache-warmup --stop-on-failure
 ```
 
 | Shorthand               | –      |
@@ -498,7 +516,7 @@ object. It includes the following properties:
 
 | Property            | Description                                                                                                            |
 |---------------------|------------------------------------------------------------------------------------------------------------------------|
-| `cacheWarmupResult` | Lists all crawled URLs, grouped by their crawling state (`failure`, `success`)                                         |
+| `cacheWarmupResult` | Lists all crawled URLs, grouped by their crawling state (`failure`, `success`), and may contain `cancelled` state      |
 | `messages`          | Contains all logged messages, grouped by message severity (`error`, `info`, `success`, `warning`)                      |
 | `parserResult`      | Lists all parsed and excluded XML sitemaps and URLs, grouped by their parsing state (`excluded`, `failure`, `success`) |
 | `time`              | Lists all tracked times during cache warmup (`crawl`, `parse`)                                                         |
@@ -535,3 +553,4 @@ This project is licensed under [GNU General Public License 3.0 (or later)](LICEN
 [20]: https://github.com/eliashaeussler/cache-warmup/releases/latest
 [21]: https://github.com/eliashaeussler/cache-warmup/pkgs/container/cache-warmup
 [22]: res/cache-warmup-result.schema.json
+[23]: src/Crawler/StoppableCrawlerInterface.php

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 		"composer-runtime-api": "^2.1",
 		"cuyz/valinor": "^1.3",
 		"guzzlehttp/guzzle": "^7.0",
+		"guzzlehttp/promises": "^1.0 || ^2.0",
 		"guzzlehttp/psr7": "^2.0",
 		"mtownsend/xml-to-array": "^2.0",
 		"psr/http-message": "^1.0 || ^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53702d7294abe53e0a8a9211c2926c94",
+    "content-hash": "cdd5dedcca7a7121b439f9360d671e15",
     "packages": [
         {
             "name": "cuyz/valinor",

--- a/res/cache-warmup-result.schema.json
+++ b/res/cache-warmup-result.schema.json
@@ -8,6 +8,11 @@
 			"title": "Cache warmup result",
 			"description": "Lists all crawled URLs, grouped by their crawling result.",
 			"properties": {
+				"cancelled": {
+					"type": "boolean",
+					"title": "Cache warmup cancellation state",
+					"description": "Indicates whether cache warmup was cancelled prematurely."
+				},
 				"failure": {
 					"$ref": "#/definitions/urls"
 				},

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -50,12 +50,14 @@ trait ConcurrentCrawlerTrait
         array $urls,
         ClientInterface $client,
         array $handlers = [],
+        bool $stopOnFailure = false,
     ): Pool {
         return Http\Message\RequestPoolFactory::create($this->buildRequests($urls))
             ->withClient($client)
             ->withConcurrency($this->options['concurrency'])
             ->withOptions($this->options['request_options'])
             ->withResponseHandler(...array_values($handlers))
+            ->withStopOnFailure($stopOnFailure)
             ->createPool()
         ;
     }

--- a/src/Crawler/CrawlerFactory.php
+++ b/src/Crawler/CrawlerFactory.php
@@ -48,6 +48,7 @@ final class CrawlerFactory
         private readonly Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
         private readonly ?Log\LoggerInterface $logger = null,
         private readonly string $logLevel = Log\LogLevel::ERROR,
+        private readonly bool $stopOnFailure = false,
     ) {}
 
     /**
@@ -73,6 +74,10 @@ final class CrawlerFactory
         if ($crawler instanceof LoggingCrawlerInterface && null !== $this->logger) {
             $crawler->setLogger($this->logger);
             $crawler->setLogLevel($this->logLevel);
+        }
+
+        if ($crawler instanceof StoppableCrawlerInterface) {
+            $crawler->stopOnFailure($this->stopOnFailure);
         }
 
         return $crawler;

--- a/src/Crawler/StoppableCrawlerInterface.php
+++ b/src/Crawler/StoppableCrawlerInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Crawler;
+
+/**
+ * StoppableCrawlerInterface.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+interface StoppableCrawlerInterface extends CrawlerInterface
+{
+    public function stopOnFailure(bool $stopOnFailure = true): void;
+}

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -31,7 +31,7 @@ use Symfony\Component\Console;
 
 use function array_map;
 use function is_array;
-use function is_string;
+use function is_scalar;
 use function json_encode;
 
 /**
@@ -57,6 +57,7 @@ use function json_encode;
  *     cacheWarmupResult?: array{
  *         success?: list<string>,
  *         failure?: list<string>,
+ *         cancelled?: bool,
  *     },
  *     messages?: array<value-of<MessageSeverity>, list<string>>,
  *     time?: array{
@@ -108,6 +109,10 @@ final class JsonFormatter implements Formatter
         $this->addToJson('cacheWarmupResult/success', $result->getSuccessful());
         $this->addToJson('cacheWarmupResult/failure', $result->getFailed());
 
+        if ($result->wasCancelled()) {
+            $this->addToJson('cacheWarmupResult/cancelled', true);
+        }
+
         if (null !== $duration) {
             $this->addToJson('time/crawl', $duration->format());
         }
@@ -145,11 +150,11 @@ final class JsonFormatter implements Formatter
     }
 
     /**
-     * @param string|list<bool|float|int|resource|string|Stringable|null> $value
+     * @param string|bool|list<bool|float|int|resource|string|Stringable|null> $value
      */
-    private function addToJson(string $path, string|array $value): void
+    private function addToJson(string $path, string|bool|array $value): void
     {
-        if (is_string($value) && '' !== $value) {
+        if (is_scalar($value) && '' !== $value) {
             Helper\ArrayHelper::setValueByPath($this->json, $path, $value);
         }
         if (is_array($value) && [] !== $value) {

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -159,10 +159,19 @@ final class TextFormatter implements Formatter
                 ),
             );
         }
+        if ($result->wasCancelled()) {
+            $this->io->warning('Cache warmup was cancelled due to a crawling failure.');
+        }
 
         // Print duration
         if (null !== $duration) {
-            $this->io->writeln(sprintf('Crawling finished in %s', $duration->format()));
+            $this->io->writeln(
+                sprintf(
+                    'Crawling %s %s',
+                    $result->wasCancelled() ? 'cancelled after' : 'finished in',
+                    $duration->format(),
+                ),
+            );
             $this->io->newLine();
         }
     }

--- a/src/Result/CacheWarmupResult.php
+++ b/src/Result/CacheWarmupResult.php
@@ -40,6 +40,7 @@ final class CacheWarmupResult
      * @var list<CrawlingResult>
      */
     private array $failed = [];
+    private bool $cancelled = false;
 
     public function addResult(CrawlingResult $result): self
     {
@@ -71,5 +72,15 @@ final class CacheWarmupResult
     public function isSuccessful(): bool
     {
         return [] === $this->failed;
+    }
+
+    public function wasCancelled(): bool
+    {
+        return $this->cancelled;
+    }
+
+    public function setCancelled(bool $cancelled): void
+    {
+        $this->cancelled = $cancelled;
     }
 }

--- a/tests/src/Command/CacheWarmupCommandTest.php
+++ b/tests/src/Command/CacheWarmupCommandTest.php
@@ -377,6 +377,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     public function executeUsesCrawlerOptions(array|string $crawlerOptions): void
     {
         $this->mockSitemapRequest('valid_sitemap_3');
+
         $this->commandTester->execute(
             [
                 'sitemaps' => [
@@ -400,6 +401,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
     public function executeShowsWarningIfCrawlerOptionsArePassedToNonConfigurableCrawler(): void
     {
         $this->mockSitemapRequest('valid_sitemap_3');
+
         $this->commandTester->execute([
             'sitemaps' => [
                 'https://www.example.com/sitemap.xml',
@@ -412,6 +414,25 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         self::assertNotEmpty($output);
         self::assertStringContainsString('You passed crawler options for a non-configurable crawler.', $output);
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeShowsWarningIfStopOnFailureOptionIsPassedToNonStoppableCrawler(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--crawler' => Tests\Crawler\DummyCrawler::class,
+            '--stop-on-failure' => true,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertNotEmpty($output);
+        self::assertStringContainsString('You passed --stop-on-failure to a non-stoppable crawler.', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -524,6 +545,24 @@ final class CacheWarmupCommandTest extends Framework\TestCase
 
         self::assertFileExists($logFile);
         self::assertNotEmpty((string) file_get_contents($logFile));
+    }
+
+    #[Framework\Attributes\Test]
+    public function executeStopsOnFailureWithStopOnFailureOptionAndStoppableCrawlerGiven(): void
+    {
+        $this->mockSitemapRequest('valid_sitemap_3');
+
+        $this->commandTester->execute([
+            'sitemaps' => [
+                'https://www.example.com/sitemap.xml',
+            ],
+            '--stop-on-failure' => true,
+        ]);
+
+        $output = $this->commandTester->getDisplay();
+
+        self::assertNotEmpty($output);
+        self::assertStringContainsString('Cancelled', $output);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Crawler/CrawlerFactoryTest.php
+++ b/tests/src/Crawler/CrawlerFactoryTest.php
@@ -45,7 +45,12 @@ final class CrawlerFactoryTest extends Framework\TestCase
     {
         $this->output = new Console\Output\BufferedOutput();
         $this->logger = new Src\Tests\Log\DummyLogger();
-        $this->subject = new Src\Crawler\CrawlerFactory($this->output, $this->logger);
+        $this->subject = new Src\Crawler\CrawlerFactory(
+            $this->output,
+            $this->logger,
+            Log\LogLevel::ERROR,
+            true,
+        );
     }
 
     #[Framework\Attributes\Test]
@@ -107,6 +112,17 @@ final class CrawlerFactoryTest extends Framework\TestCase
 
         DummyLoggingCrawler::$logger = null;
         DummyLoggingCrawler::$logLevel = null;
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsStoppableCrawler(): void
+    {
+        $actual = $this->subject->get(DummyStoppableCrawler::class);
+
+        self::assertInstanceOf(DummyStoppableCrawler::class, $actual);
+        self::assertTrue(DummyStoppableCrawler::$stopOnFailure);
+
+        DummyStoppableCrawler::$stopOnFailure = false;
     }
 
     #[Framework\Attributes\Test]

--- a/tests/src/Crawler/DummyStoppableCrawler.php
+++ b/tests/src/Crawler/DummyStoppableCrawler.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2023 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
+
+use EliasHaeussler\CacheWarmup\Crawler;
+
+/**
+ * DummyStoppableCrawler.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class DummyStoppableCrawler extends DummyCrawler implements Crawler\StoppableCrawlerInterface
+{
+    public static bool $stopOnFailure = false;
+
+    public function stopOnFailure(bool $stopOnFailure = true): void
+    {
+        self::$stopOnFailure = $stopOnFailure;
+    }
+}

--- a/tests/src/Formatter/JsonFormatterTest.php
+++ b/tests/src/Formatter/JsonFormatterTest.php
@@ -206,6 +206,24 @@ final class JsonFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultAddsCancelledState(): void
+    {
+        $result = new Src\Result\CacheWarmupResult();
+        $result->setCancelled(true);
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        self::assertSame(
+            [
+                'cacheWarmupResult' => [
+                    'cancelled' => true,
+                ],
+            ],
+            $this->subject->getJson(),
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function formatCacheWarmupResultAddsDuration(): void
     {
         $result = new Src\Result\CacheWarmupResult();

--- a/tests/src/Formatter/TextFormatterTest.php
+++ b/tests/src/Formatter/TextFormatterTest.php
@@ -278,6 +278,20 @@ final class TextFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function formatCacheWarmupResultPrintsResultMessageOnCancelledCacheWarmup(): void
+    {
+        $result = new Src\Result\CacheWarmupResult();
+        $result->setCancelled(true);
+
+        $this->subject->formatCacheWarmupResult($result);
+
+        $output = $this->output->fetch();
+
+        self::assertNotEmpty($output);
+        self::assertStringContainsString('Cache warmup was cancelled due to a crawling failure.', $output);
+    }
+
+    #[Framework\Attributes\Test]
     public function formatCacheWarmupResultPrintsDuration(): void
     {
         $result = new Src\Result\CacheWarmupResult();

--- a/tests/src/Http/Message/RequestPoolFactoryTest.php
+++ b/tests/src/Http/Message/RequestPoolFactoryTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Http\Message;
 use EliasHaeussler\CacheWarmup as Src;
 use EliasHaeussler\CacheWarmup\Tests;
 use Exception;
+use GuzzleHttp\Promise;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework;
@@ -144,6 +145,21 @@ final class RequestPoolFactoryTest extends Framework\TestCase
 
         self::assertCount(2, $handler->successful);
         self::assertCount(1, $handler->failed);
+    }
+
+    #[Framework\Attributes\Test]
+    public function withStopOnFailureClonesObjectAndConfiguresStopOnFailure(): void
+    {
+        $this->mockHandler->append(
+            new Psr7\Response(),
+            new Exception(),
+        );
+
+        $actual = $this->subject->withStopOnFailure();
+
+        $this->expectException(Promise\CancellationException::class);
+
+        $actual->createPool()->promise()->wait();
     }
 
     private function assertPropertyEquals(object $object, string $property, mixed $expected): void

--- a/tests/src/Result/CacheWarmupResultTest.php
+++ b/tests/src/Result/CacheWarmupResultTest.php
@@ -86,4 +86,14 @@ final class CacheWarmupResultTest extends Framework\TestCase
 
         self::assertFalse($this->subject->isSuccessful());
     }
+
+    #[Framework\Attributes\Test]
+    public function wasCancelledReturnsTrueIfCacheWarmupWasCancelled(): void
+    {
+        self::assertFalse($this->subject->wasCancelled());
+
+        $this->subject->setCancelled(true);
+
+        self::assertTrue($this->subject->wasCancelled());
+    }
 }


### PR DESCRIPTION
This PR introduces stoppable crawlers. Each crawler implementing `EliasHaeussler\CacheWarmup\Crawler\StoppableCrawlerInterface` provides a `stopOnFailure()` method to stop cache warmup in case a failure occurs. Both default crawlers now implement this interface. In addition, a new command option `--stop-on-failure` is added.

Resolves: #301