### PR TITLE
[TASK] Avoid `@phpstan-ignore-next-line` annotations

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,16 @@
 parameters:
 	ignoreErrors:
 		-
+			message: "#^Instanceof between EliasHaeussler\\\\CacheWarmup\\\\Sitemap\\\\Sitemap and EliasHaeussler\\\\CacheWarmup\\\\Sitemap\\\\Sitemap will always evaluate to true\\.$#"
+			count: 1
+			path: src/CacheWarmer.php
+
+		-
+			message: "#^Property EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\AbstractConfigurableCrawler\\<TOptions of array\\<string, mixed\\>\\>\\:\\:\\$options \\(TOptions of array\\<string, mixed\\>\\) does not accept array\\<string, mixed\\>\\.$#"
+			count: 1
+			path: src/Crawler/AbstractConfigurableCrawler.php
+
+		-
 			message: "#^Parameter \\#1 \\$level \\('alert'\\|'critical'\\|'debug'\\|'emergency'\\|'error'\\|'info'\\|'notice'\\|'warning'\\) of method EliasHaeussler\\\\CacheWarmup\\\\Log\\\\FileLogger\\:\\:log\\(\\) should be contravariant with parameter \\$level \\(mixed\\) of method Psr\\\\Log\\\\AbstractLogger\\:\\:log\\(\\)$#"
 			count: 1
 			path: src/Log/FileLogger.php
@@ -29,3 +39,18 @@ parameters:
 			message: "#^Parameter \\#3 \\$context \\(array\\<string, mixed\\>\\) of method EliasHaeussler\\\\CacheWarmup\\\\Log\\\\FileLogger\\:\\:log\\(\\) should be contravariant with parameter \\$context \\(array\\) of method Psr\\\\Log\\\\LoggerTrait\\:\\:log\\(\\)$#"
 			count: 1
 			path: src/Log/FileLogger.php
+
+		-
+			message: "#^Parameter \\#1 \\$sitemaps of method EliasHaeussler\\\\CacheWarmup\\\\CacheWarmer\\:\\:addSitemaps\\(\\) expects list\\<EliasHaeussler\\\\CacheWarmup\\\\Sitemap\\\\Sitemap\\|string\\>\\|EliasHaeussler\\\\CacheWarmup\\\\Sitemap\\\\Sitemap\\|string, array\\{false\\} given\\.$#"
+			count: 1
+			path: tests/src/CacheWarmerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerInterface\\>, string given\\.$#"
+			count: 2
+			path: tests/src/Crawler/CrawlerFactoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$crawlerOptions of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:parseCrawlerOptions\\(\\) expects array\\<string, mixed\\>\\|string\\|null, array\\<int, string\\> given\\.$#"
+			count: 1
+			path: tests/src/Crawler/CrawlerFactoryTest.php

--- a/src/CacheWarmer.php
+++ b/src/CacheWarmer.php
@@ -129,7 +129,6 @@ final class CacheWarmer
             }
 
             // Throw exception if sitemap is invalid
-            /* @phpstan-ignore-next-line */
             if (!($sitemap instanceof Sitemap\Sitemap)) {
                 throw Exception\InvalidSitemapException::forInvalidType($sitemap);
             }

--- a/src/Crawler/AbstractConfigurableCrawler.php
+++ b/src/Crawler/AbstractConfigurableCrawler.php
@@ -66,7 +66,6 @@ abstract class AbstractConfigurableCrawler implements ConfigurableCrawlerInterfa
             throw Exception\InvalidCrawlerOptionException::createForAll($this, array_keys($invalidOptions));
         }
 
-        /* @phpstan-ignore-next-line */
         $this->options = [...static::$defaultOptions, ...$options];
     }
 }

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -28,6 +28,7 @@ use EliasHaeussler\CacheWarmup\Result;
 use EliasHaeussler\CacheWarmup\Time;
 use Symfony\Component\Console;
 
+use function call_user_func;
 use function method_exists;
 use function sprintf;
 
@@ -181,8 +182,7 @@ final class TextFormatter implements Formatter
         $methodName = $severity->value;
 
         if (method_exists($this->io, $methodName)) {
-            /* @phpstan-ignore-next-line */
-            $this->io->{$methodName}($message);
+            call_user_func([$this->io, $methodName], $message);
         }
     }
 

--- a/tests/src/CacheWarmerTest.php
+++ b/tests/src/CacheWarmerTest.php
@@ -96,7 +96,6 @@ final class CacheWarmerTest extends Framework\TestCase
         $this->expectExceptionCode(1604055096);
         $this->expectExceptionMessage(sprintf('Sitemaps must be of type string or %s, bool given.', Src\Sitemap\Sitemap::class));
 
-        /* @phpstan-ignore-next-line */
         $this->subject->addSitemaps([false]);
     }
 

--- a/tests/src/Crawler/CrawlerFactoryTest.php
+++ b/tests/src/Crawler/CrawlerFactoryTest.php
@@ -60,7 +60,6 @@ final class CrawlerFactoryTest extends Framework\TestCase
     {
         $this->expectExceptionObject(Src\Exception\InvalidCrawlerException::forMissingClass('foo'));
 
-        /* @phpstan-ignore-next-line */
         $this->subject->get('foo');
     }
 
@@ -69,7 +68,6 @@ final class CrawlerFactoryTest extends Framework\TestCase
     {
         $this->expectExceptionObject(Src\Exception\InvalidCrawlerException::forUnsupportedClass(self::class));
 
-        /* @phpstan-ignore-next-line */
         $this->subject->get(self::class);
     }
 
@@ -157,7 +155,6 @@ final class CrawlerFactoryTest extends Framework\TestCase
     {
         $this->expectExceptionObject(Src\Exception\InvalidCrawlerOptionException::forInvalidType(['foo']));
 
-        /* @phpstan-ignore-next-line */
         $this->subject->parseCrawlerOptions(['foo']);
     }
 


### PR DESCRIPTION
This PR removes all `@phpstan-ignore-next-line` annotations and instead adds errors to the baseline.