### PR TITLE
[FEATURE] Create client on-the-fly before crawling URLs

### DIFF
--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -59,7 +59,6 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
         'client_config' => [],
     ];
 
-    private readonly ClientInterface $client;
     private Console\Output\OutputInterface $output;
     private ?Log\LoggerInterface $logger = null;
 
@@ -71,11 +70,9 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
 
     public function __construct(
         array $options = [],
-        ?ClientInterface $client = null,
+        private readonly ?ClientInterface $client = null,
     ) {
         parent::__construct($options);
-
-        $this->client = $client ?? new Client($this->options['client_config']);
         $this->output = new Console\Output\ConsoleOutput();
     }
 
@@ -101,8 +98,11 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
             $handlers[] = $logHandler;
         }
 
+        // Create new client
+        $client = $this->client ?? new Client($this->options['client_config']);
+
         // Create request pool
-        $pool = $this->createPool($urls, $this->client, $handlers, $this->stopOnFailure);
+        $pool = $this->createPool($urls, $client, $handlers, $this->stopOnFailure);
 
         // Start crawling
         try {

--- a/tests/src/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/src/Crawler/ConcurrentCrawlerTest.php
@@ -56,7 +56,7 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function constructorInstantiatesClientWithGivenClientConfig(): void
+    public function crawlInstantiatesClientWithGivenClientConfig(): void
     {
         $this->mockHandler->append(new Psr7\Response());
 
@@ -76,7 +76,7 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function constructorIgnoresGivenClientConfigIfInstantiatedClientIsPassed(): void
+    public function crawlIgnoresGivenClientConfigIfInstantiatedClientIsPassed(): void
     {
         $subject = new Src\Crawler\ConcurrentCrawler(
             [

--- a/tests/src/Crawler/OutputtingCrawlerTest.php
+++ b/tests/src/Crawler/OutputtingCrawlerTest.php
@@ -60,7 +60,7 @@ final class OutputtingCrawlerTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function constructorInstantiatesClientWithGivenClientConfig(): void
+    public function crawlInstantiatesClientWithGivenClientConfig(): void
     {
         $this->mockHandler->append(new Psr7\Response());
 
@@ -81,7 +81,7 @@ final class OutputtingCrawlerTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function constructorIgnoresGivenClientConfigIfInstantiatedClientIsPassed(): void
+    public function crawlIgnoresGivenClientConfigIfInstantiatedClientIsPassed(): void
     {
         $subject = new Src\Crawler\OutputtingCrawler(
             [


### PR DESCRIPTION
This PR changes the way how clients are initialized in the default crawlers: Clients are now instantiated on-the-fly right before crawling is started. This allows to change client config using crawler options, even after the crawler is already initialized.