### PR TITLE
[TASK] Streamline log messages in command output

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -568,7 +568,7 @@ HELP);
             }
         } elseif ([] !== $crawlerOptions) {
             $this->formatter->logMessage(
-                'You passed crawler options for a non-configurable crawler.',
+                'You passed crawler options to a non-configurable crawler.',
                 Formatter\MessageSeverity::Warning,
             );
         }
@@ -576,7 +576,7 @@ HELP);
         // Show notice on unsupported stoppable crawler feature
         if ($stopOnFailure && !($crawler instanceof Crawler\StoppableCrawlerInterface)) {
             $this->formatter->logMessage(
-                'You passed --stop-on-failure to a non-stoppable crawler.',
+                'You configured "stop on failure" for a non-stoppable crawler.',
                 Formatter\MessageSeverity::Warning,
             );
         }

--- a/tests/src/Command/CacheWarmupCommandTest.php
+++ b/tests/src/Command/CacheWarmupCommandTest.php
@@ -493,7 +493,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         $output = $this->commandTester->getDisplay();
 
         self::assertNotEmpty($output);
-        self::assertStringContainsString('You passed crawler options for a non-configurable crawler.', $output);
+        self::assertStringContainsString('You passed crawler options to a non-configurable crawler.', $output);
     }
 
     #[Framework\Attributes\Test]
@@ -512,7 +512,7 @@ final class CacheWarmupCommandTest extends Framework\TestCase
         $output = $this->commandTester->getDisplay();
 
         self::assertNotEmpty($output);
-        self::assertStringContainsString('You passed --stop-on-failure to a non-stoppable crawler.', $output);
+        self::assertStringContainsString('You configured "stop on failure" for a non-stoppable crawler.', $output);
     }
 
     #[Framework\Attributes\Test]


### PR DESCRIPTION
This PR streamlines log messages in command output to always display configuration options the same way.