### PR TITLE
[BUGFIX] Treat config file from env variable with higher priority

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -344,11 +344,11 @@ HELP);
             new Config\Adapter\EnvironmentVariablesConfigAdapter(),
         ];
 
-        if (null !== $configFile) {
-            array_unshift($configAdapters, $this->loadConfigFromFile($configFile));
-        }
         if (false !== $configFileFromEnv) {
             array_unshift($configAdapters, $this->loadConfigFromFile($configFileFromEnv));
+        }
+        if (null !== $configFile) {
+            array_unshift($configAdapters, $this->loadConfigFromFile($configFile));
         }
 
         $this->config = (new Config\Adapter\CompositeConfigAdapter($configAdapters))->get();


### PR DESCRIPTION
This PR changes the way how config files are interpreted: If an environment variable `CACHE_WARMUP_CONFIG` is set along with the `--config` command parameter, the environment variable receives higher priority and thus the provided config file will be loaded later.