### PR TITLE
[!!!][FEATURE] Use Symfony OptionsResolver for crawler options

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"psr/log": "^2.0 || ^3.0",
 		"symfony/console": "^5.4 || ^6.0 || ^7.0",
 		"symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
+		"symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",
 		"symfony/yaml": "^5.4 || ^6.0 || ^7.0"
 	},
 	"require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dfd2057b2ec06b1240fc2115fe966966",
+    "content-hash": "08e5cfdf4a585894e534573fe8cfa498",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -1038,6 +1038,73 @@
                 }
             ],
             "time": "2024-01-23T14:51:35+00:00"
+        },
+        {
+            "name": "symfony/options-resolver",
+            "version": "v6.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/options-resolver.git",
+                "reference": "22301f0e7fdeaacc14318928612dee79be99860e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/22301f0e7fdeaacc14318928612dee79be99860e",
+                "reference": "22301f0e7fdeaacc14318928612dee79be99860e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\OptionsResolver\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides an improved replacement for the array_replace PHP function",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "config",
+                "configuration",
+                "options"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/options-resolver/tree/v6.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2023-08-08T10:16:24+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5082,73 +5149,6 @@
                 }
             ],
             "time": "2024-01-30T08:32:12+00:00"
-        },
-        {
-            "name": "symfony/options-resolver",
-            "version": "v6.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "22301f0e7fdeaacc14318928612dee79be99860e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/22301f0e7fdeaacc14318928612dee79be99860e",
-                "reference": "22301f0e7fdeaacc14318928612dee79be99860e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\OptionsResolver\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides an improved replacement for the array_replace PHP function",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "config",
-                "configuration",
-                "options"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v6.4.0"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2023-08-08T10:16:24+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -21,7 +21,7 @@ parameters:
 			path: src/Config/CacheWarmupConfig.php
 
 		-
-			message: "#^Property EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\AbstractConfigurableCrawler\\<TOptions of array\\<string, mixed\\>\\>\\:\\:\\$options \\(TOptions of array\\<string, mixed\\>\\) does not accept array\\<string, mixed\\>\\.$#"
+			message: "#^Property EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\AbstractConfigurableCrawler\\<TOptions of array\\<string, mixed\\>\\>\\:\\:\\$options \\(TOptions of array\\<string, mixed\\>\\) does not accept array\\.$#"
 			count: 1
 			path: src/Crawler/AbstractConfigurableCrawler.php
 

--- a/src/Crawler/AbstractConfigurableCrawler.php
+++ b/src/Crawler/AbstractConfigurableCrawler.php
@@ -23,9 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
-use EliasHaeussler\CacheWarmup\Exception;
-
-use function array_diff_key;
+use Symfony\Component\OptionsResolver;
 
 /**
  * AbstractConfigurableCrawler.
@@ -37,10 +35,7 @@ use function array_diff_key;
  */
 abstract class AbstractConfigurableCrawler implements ConfigurableCrawlerInterface
 {
-    /**
-     * @var TOptions
-     */
-    protected static array $defaultOptions = [];
+    protected OptionsResolver\OptionsResolver $optionsResolver;
 
     /**
      * @var TOptions
@@ -52,20 +47,18 @@ abstract class AbstractConfigurableCrawler implements ConfigurableCrawlerInterfa
      */
     public function __construct(array $options = [])
     {
+        $this->optionsResolver = new OptionsResolver\OptionsResolver();
+        $this->configureOptions($this->optionsResolver);
         $this->setOptions($options);
     }
+
+    abstract protected function configureOptions(OptionsResolver\OptionsResolver $optionsResolver): void;
 
     /**
      * @param array<string, mixed> $options
      */
     public function setOptions(array $options): void
     {
-        $invalidOptions = array_diff_key($options, static::$defaultOptions);
-
-        if ([] !== $invalidOptions) {
-            throw Exception\InvalidCrawlerOptionException::createForAll($this, array_keys($invalidOptions));
-        }
-
-        $this->options = [...static::$defaultOptions, ...$options];
+        $this->options = $this->optionsResolver->resolve($options);
     }
 }

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -48,14 +48,6 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
 {
     use ConcurrentCrawlerTrait;
 
-    protected static array $defaultOptions = [
-        'concurrency' => 5,
-        'request_method' => 'HEAD',
-        'request_headers' => [],
-        'request_options' => [],
-        'client_config' => [],
-    ];
-
     private ?Log\LoggerInterface $logger = null;
 
     /**

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -30,6 +30,7 @@ use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Pool;
 use GuzzleHttp\Psr7;
 use Psr\Http\Message;
+use Symfony\Component\OptionsResolver;
 
 use function sprintf;
 
@@ -41,6 +42,36 @@ use function sprintf;
  */
 trait ConcurrentCrawlerTrait
 {
+    protected function configureOptions(OptionsResolver\OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->define('concurrency')
+            ->allowedTypes('int')
+            ->required()
+            ->default(5)
+        ;
+
+        $optionsResolver->define('request_method')
+            ->allowedTypes('string')
+            ->required()
+            ->default('HEAD')
+        ;
+
+        $optionsResolver->define('request_headers')
+            ->allowedTypes('array')
+            ->default([])
+        ;
+
+        $optionsResolver->define('request_options')
+            ->allowedTypes('array')
+            ->default([])
+        ;
+
+        $optionsResolver->define('client_config')
+            ->allowedTypes('array')
+            ->default([])
+        ;
+    }
+
     /**
      * @param list<Message\UriInterface>                          $urls
      * @param list<Http\Message\Handler\ResponseHandlerInterface> $handlers

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -51,14 +51,6 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
 {
     use ConcurrentCrawlerTrait;
 
-    protected static array $defaultOptions = [
-        'concurrency' => 5,
-        'request_method' => 'HEAD',
-        'request_headers' => [],
-        'request_options' => [],
-        'client_config' => [],
-    ];
-
     private Console\Output\OutputInterface $output;
     private ?Log\LoggerInterface $logger = null;
 

--- a/src/Exception/InvalidCrawlerOptionException.php
+++ b/src/Exception/InvalidCrawlerOptionException.php
@@ -26,10 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Exception;
 use EliasHaeussler\CacheWarmup\Crawler;
 use RuntimeException;
 
-use function array_pop;
-use function count;
 use function get_debug_type;
-use function implode;
 use function sprintf;
 
 /**
@@ -45,28 +42,6 @@ final class InvalidCrawlerOptionException extends RuntimeException
         return new self(
             sprintf('The crawler option "%s" is invalid or not supported by crawler "%s".', $option, $crawler::class),
             1659120894,
-        );
-    }
-
-    /**
-     * @param list<string> $options
-     */
-    public static function createForAll(Crawler\ConfigurableCrawlerInterface $crawler, array $options): self
-    {
-        if (1 === count($options)) {
-            return self::create($crawler, $options[0]);
-        }
-
-        $lastOption = array_pop($options);
-
-        return new self(
-            sprintf(
-                'The crawler options "%s" and "%s" are invalid or not supported by crawler "%s".',
-                implode('", "', $options),
-                $lastOption,
-                $crawler::class,
-            ),
-            1659206995,
         );
     }
 

--- a/tests/src/Crawler/AbstractConfigurableCrawlerTest.php
+++ b/tests/src/Crawler/AbstractConfigurableCrawlerTest.php
@@ -26,6 +26,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
 use EliasHaeussler\CacheWarmup as Src;
 use EliasHaeussler\CacheWarmup\Tests;
 use PHPUnit\Framework;
+use Symfony\Component\OptionsResolver;
 
 /**
  * AbstractConfigurableCrawlerTest.
@@ -57,11 +58,7 @@ final class AbstractConfigurableCrawlerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function setOptionsThrowsExceptionIfInvalidOptionsAreGiven(): void
     {
-        $this->expectException(Src\Exception\InvalidCrawlerOptionException::class);
-        $this->expectExceptionCode(1659206995);
-        $this->expectExceptionMessage(
-            'The crawler options "dummy" and "blub" are invalid or not supported by crawler "'.$this->subject::class.'".',
-        );
+        $this->expectException(OptionsResolver\Exception\UndefinedOptionsException::class);
 
         $this->subject->setOptions([
             'foo' => 'bar',

--- a/tests/src/Exception/InvalidCrawlerOptionExceptionTest.php
+++ b/tests/src/Exception/InvalidCrawlerOptionExceptionTest.php
@@ -27,8 +27,6 @@ use EliasHaeussler\CacheWarmup as Src;
 use EliasHaeussler\CacheWarmup\Tests;
 use PHPUnit\Framework;
 
-use function sprintf;
-
 /**
  * InvalidCrawlerOptionExceptionTest.
  *
@@ -47,36 +45,6 @@ final class InvalidCrawlerOptionExceptionTest extends Framework\TestCase
         self::assertSame(1659120894, $actual->getCode());
         self::assertSame(
             'The crawler option "foo" is invalid or not supported by crawler "'.$crawler::class.'".',
-            $actual->getMessage(),
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function createForAllReturnsExceptionForGivenCrawlerAndOptionIfOnlyOneOptionIsGiven(): void
-    {
-        $crawler = new Tests\Fixtures\Classes\DummyConfigurableCrawler();
-        $actual = Src\Exception\InvalidCrawlerOptionException::createForAll($crawler, ['foo']);
-
-        self::assertSame(1659120894, $actual->getCode());
-        self::assertSame(
-            'The crawler option "foo" is invalid or not supported by crawler "'.$crawler::class.'".',
-            $actual->getMessage(),
-        );
-    }
-
-    #[Framework\Attributes\Test]
-    public function createForAllReturnsExceptionForGivenCrawlerAndOptions(): void
-    {
-        $crawler = new Tests\Fixtures\Classes\DummyConfigurableCrawler();
-
-        $actual = Src\Exception\InvalidCrawlerOptionException::createForAll($crawler, ['foo', 'bar', 'baz']);
-
-        self::assertSame(1659206995, $actual->getCode());
-        self::assertSame(
-            sprintf(
-                'The crawler options "foo", "bar" and "baz" are invalid or not supported by crawler "%s".',
-                $crawler::class,
-            ),
             $actual->getMessage(),
         );
     }

--- a/tests/src/Fixtures/Classes/DummyConfigurableCrawler.php
+++ b/tests/src/Fixtures/Classes/DummyConfigurableCrawler.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes;
 
 use EliasHaeussler\CacheWarmup\Crawler;
 use EliasHaeussler\CacheWarmup\Result;
+use Symfony\Component\OptionsResolver;
 
 /**
  * DummyConfigurableCrawler.
@@ -38,11 +39,6 @@ use EliasHaeussler\CacheWarmup\Result;
  */
 final class DummyConfigurableCrawler extends Crawler\AbstractConfigurableCrawler
 {
-    protected static array $defaultOptions = [
-        'foo' => 'hello world',
-        'bar' => 42,
-    ];
-
     public function crawl(array $urls): Result\CacheWarmupResult
     {
         return new Result\CacheWarmupResult();
@@ -54,5 +50,18 @@ final class DummyConfigurableCrawler extends Crawler\AbstractConfigurableCrawler
     public function getOptions(): array
     {
         return $this->options;
+    }
+
+    protected function configureOptions(OptionsResolver\OptionsResolver $optionsResolver): void
+    {
+        $optionsResolver->define('foo')
+            ->allowedTypes('string')
+            ->default('hello world')
+        ;
+
+        $optionsResolver->define('bar')
+            ->allowedTypes('int')
+            ->default(42)
+        ;
     }
 }


### PR DESCRIPTION
This PR requires and implements Symfony's *OptionsResolver* component to properly handle crawler options of the default crawlers.