### PR TITLE
[!!!][FEATURE] Drop `Interface` suffix from interfaces

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -40,7 +40,7 @@ Support for gzipped XML sitemaps
 :::
 
 ::: info 🧑‍💻
-Interface for [custom crawler](api/index.md#crawlerinterface) implementations
+Interface for [custom crawler](api/index.md#crawler) implementations
 :::
 
 … and [many more](config-reference/index.md)!

--- a/docs/api/configurable-crawler.md
+++ b/docs/api/configurable-crawler.md
@@ -5,16 +5,16 @@ outline: [2,3]
 # Configurable Crawler
 
 Whenever you want to allow a custom behavior of your crawler, it
-should implement the
-[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConfigurableCrawlerInterface.php):
+should implement
+[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConfigurableCrawler.php):
 
 ```php
 namespace Vendor\Crawler;
 
 use EliasHaeussler\CacheWarmup;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\CrawlerInterface // [!code --]
-final class MyCustomCrawler implements CacheWarmup\Crawler\ConfigurableCrawlerInterface // [!code ++]
+final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler // [!code --]
+final class MyCustomCrawler implements CacheWarmup\Crawler\ConfigurableCrawler // [!code ++]
 {
     // ...
 }
@@ -38,7 +38,7 @@ namespace Vendor\Crawler;
 use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\ConfigurableCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\ConfigurableCrawler
 {
     private array $options = [ // [!code ++]
         'request_method' => 'GET', // [!code ++]
@@ -75,7 +75,7 @@ use EliasHaeussler\CacheWarmup;
 use GuzzleHttp\ClientInterface;
 use Psr\Http\Message;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\ConfigurableCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\ConfigurableCrawler
 {
     private array $options = [
         'request_method' => 'GET',

--- a/docs/api/crawler.md
+++ b/docs/api/crawler.md
@@ -6,15 +6,15 @@ outline: [2,3]
 
 Crawlers are the core component of the library. They are used
 to perform the actual requests for all configured URLs to warm
-up their website caches. Each crawler must implement the
-[`EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/CrawlerInterface.php):
+up their website caches. Each crawler must implement
+[`EliasHaeussler\CacheWarmup\Crawler\Crawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/Crawler.php):
 
 ```php
 namespace Vendor\Crawler;
 
 use EliasHaeussler\CacheWarmup;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\CrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler
 {
     // ...
 }
@@ -35,7 +35,7 @@ namespace Vendor\Crawler;
 use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message; // [!code ++]
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\CrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler
 {
     public function crawl(array $urls): CacheWarmup\Result\CacheWarmupResult // [!code ++]
     { // [!code ++]

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -32,10 +32,10 @@ Check out all available [options](options.md) and
 [methods](methods.md) to get an overview about possible API
 opportunities.
 
-## `CrawlerInterface`
+## `Crawler`
 
 URLs in XML sitemaps are processed by crawlers implementing
-[`EliasHaeussler\CacheWarmup\Crawler\CrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/CrawlerInterface.php).
+[`EliasHaeussler\CacheWarmup\Crawler\Crawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/Crawler.php).
 Read more about how to [create a custom crawler](crawler.md).
 
 In addition, there exist different variations of crawler

--- a/docs/api/logging-crawler.md
+++ b/docs/api/logging-crawler.md
@@ -5,16 +5,16 @@ outline: [2,3]
 # Logging Crawler
 
 In some cases it might be helpful to log parts of the cache
-warmup process. For this, your crawler should implement the
-[`EliasHaeussler\CacheWarmup\Crawler\LoggingCrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/LoggingCrawlerInterface.php):
+warmup process. For this, your crawler should implement
+[`EliasHaeussler\CacheWarmup\Crawler\LoggingCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/LoggingCrawler.php):
 
 ```php
 namespace Vendor\Crawler;
 
 use EliasHaeussler\CacheWarmup;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\CrawlerInterface // [!code --]
-final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawlerInterface // [!code ++]
+final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler // [!code --]
+final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawler // [!code ++]
 {
     // ...
 }
@@ -36,7 +36,7 @@ use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 use Psr\Log; // [!code ++]
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawler
 {
     private ?Log\LoggerInterface $logger = null; // [!code ++]
 
@@ -71,7 +71,7 @@ use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 use Psr\Log;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawler
 {
     private ?Log\LoggerInterface $logger = null;
     private string $logLevel = CacheWarmup\Log\LogLevel::ERROR; // [!code ++]
@@ -107,7 +107,7 @@ use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 use Psr\Log;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\LoggingCrawler
 {
     private ?Log\LoggerInterface $logger = null;
     private string $logLevel = CacheWarmup\Log\LogLevel::ERROR;

--- a/docs/api/stoppable-crawler.md
+++ b/docs/api/stoppable-crawler.md
@@ -5,8 +5,8 @@ outline: [2,3]
 # Stoppable Crawler
 
 In terms of error handling it might be useful to define the
-behavior in case a cache warmup failure occurs. You can implement the
-[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/StoppableCrawlerInterface.php)
+behavior in case a cache warmup failure occurs. You can implement
+[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/StoppableCrawler.php)
 to make this sort of error handling configurable:
 
 ```php
@@ -14,8 +14,8 @@ namespace Vendor\Crawler;
 
 use EliasHaeussler\CacheWarmup;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\CrawlerInterface // [!code --]
-final class MyCustomCrawler implements CacheWarmup\Crawler\StoppableCrawlerInterface // [!code ++]
+final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler // [!code --]
+final class MyCustomCrawler implements CacheWarmup\Crawler\StoppableCrawler // [!code ++]
 {
     // ...
 }
@@ -36,7 +36,7 @@ namespace Vendor\Crawler;
 use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\StoppableCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\StoppableCrawler
 {
     private bool $stopOnFailure = false; // [!code ++]
 
@@ -65,7 +65,7 @@ namespace Vendor\Crawler;
 use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\StoppableCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\StoppableCrawler
 {
     private bool $stopOnFailure = false;
 

--- a/docs/api/verbose-crawler.md
+++ b/docs/api/verbose-crawler.md
@@ -6,16 +6,16 @@ outline: [2,3]
 
 When cache warmup is performed from the command line, it might
 be helpful to provide user-oriented output such as progress bars
-or error messages. In this case, you can implement the
-[`EliasHaeussler\CacheWarmup\Crawler\VerboseCrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/VerboseCrawlerInterface.php):
+or error messages. In this case, you can implement
+[`EliasHaeussler\CacheWarmup\Crawler\VerboseCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/VerboseCrawler.php):
 
 ```php
 namespace Vendor\Crawler;
 
 use EliasHaeussler\CacheWarmup;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\CrawlerInterface // [!code --]
-final class MyCustomCrawler implements CacheWarmup\Crawler\VerboseCrawlerInterface // [!code ++]
+final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler // [!code --]
+final class MyCustomCrawler implements CacheWarmup\Crawler\VerboseCrawler // [!code ++]
 {
     // ...
 }
@@ -36,7 +36,7 @@ use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 use Symfony\Component\Console;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\VerboseCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\VerboseCrawler
 {
     private ?Console\Output\OutputInterface $output = null; // [!code ++]
 
@@ -66,7 +66,7 @@ use EliasHaeussler\CacheWarmup;
 use Psr\Http\Message;
 use Symfony\Component\Console;
 
-final class MyCustomCrawler implements CacheWarmup\Crawler\VerboseCrawlerInterface
+final class MyCustomCrawler implements CacheWarmup\Crawler\VerboseCrawler
 {
     private ?Console\Output\OutputInterface $output = null;
 

--- a/docs/config-reference/crawler-options.md
+++ b/docs/config-reference/crawler-options.md
@@ -10,7 +10,7 @@ outline: [2,3]
 
 ::: info
 These options only apply to crawlers implementing
-[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConfigurableCrawlerInterface.php).
+[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConfigurableCrawler.php).
 If the configured crawler does not implement this interface, a warning is
 shown in case crawler options are configured.
 :::

--- a/docs/config-reference/stop-on-failure.md
+++ b/docs/config-reference/stop-on-failure.md
@@ -6,7 +6,7 @@
 
 ::: info
 This option only apply to crawlers implementing
-[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawlerInterface`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/StoppableCrawlerInterface.php).
+[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/StoppableCrawler.php).
 If the configured crawler does not implement this interface, a warning is
 shown in case this flag is enabled.
 :::

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,5 +33,5 @@ features:
   - icon: 🤖
     title: Custom Crawlers
     details: Integrate custom crawlers for specialized cache warmup tailored to your website's needs.
-    link: /api/#crawlerinterface
+    link: /api/#crawler
 ---

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,12 +6,12 @@ parameters:
 			path: src/CacheWarmer.php
 
 		-
-			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerInterface\\>, string given\\.$#"
+			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
 			count: 1
 			path: src/Config/Adapter/ConsoleInputConfigAdapter.php
 
 		-
-			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerInterface\\>, string given\\.$#"
+			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
 			count: 1
 			path: src/Config/Adapter/EnvironmentVariablesConfigAdapter.php
 
@@ -66,7 +66,7 @@ parameters:
 			path: tests/src/Config/CacheWarmupConfigTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerInterface\\>, string given\\.$#"
+			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
 			count: 2
 			path: tests/src/Crawler/CrawlerFactoryTest.php
 

--- a/src/CacheWarmer.php
+++ b/src/CacheWarmer.php
@@ -74,7 +74,7 @@ final class CacheWarmer
     public function __construct(
         private readonly int $limit = 0,
         private readonly ClientInterface $client = new Client(),
-        private readonly Crawler\CrawlerInterface $crawler = new Crawler\ConcurrentCrawler(),
+        private readonly Crawler\Crawler $crawler = new Crawler\ConcurrentCrawler(),
         private readonly ?Crawler\Strategy\CrawlingStrategy $strategy = null,
         private readonly bool $strict = true,
         private readonly array $excludePatterns = [],

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -78,9 +78,9 @@ final class CacheWarmupCommand extends Console\Command\Command
 
     protected function configure(): void
     {
-        $crawlerInterface = Crawler\CrawlerInterface::class;
-        $configurableCrawlerInterface = Crawler\ConfigurableCrawlerInterface::class;
-        $stoppableCrawlerInterface = Crawler\StoppableCrawlerInterface::class;
+        $crawler = Crawler\Crawler::class;
+        $configurableCrawler = Crawler\ConfigurableCrawler::class;
+        $stoppableCrawler = Crawler\StoppableCrawler::class;
         $textFormatter = Formatter\TextFormatter::getType();
         $jsonFormatter = Formatter\JsonFormatter::getType();
         $sortByChangeFrequencyStrategy = Crawler\Strategy\SortByChangeFrequencyStrategy::getName();
@@ -166,11 +166,11 @@ This behavior can be overridden in case a special crawler is defined using the <
 
 It's up to you to ensure the given crawler class is available and fully loaded.
 This can best be achieved by registering the class with Composer autoloader.
-Also make sure the crawler implements <comment>{$crawlerInterface}</comment>.
+Also make sure the crawler implements <comment>{$crawler}</comment>.
 
 <info>Crawler options</info>
 <info>===============</info>
-For crawlers implementing <comment>{$configurableCrawlerInterface}</comment>,
+For crawlers implementing <comment>{$configurableCrawler}</comment>,
 it is possible to pass a JSON-encoded array of crawler options by using the <comment>--crawler-options</comment> option:
 
    <comment>%command.full_name% --crawler-options '{"concurrency": 3}'</comment>
@@ -198,7 +198,7 @@ this behavior by using the <comment>--allow-failures</comment> option:
 
 <info>Stop on failure</info>
 <info>===============</info>
-For crawlers implementing <comment>{$stoppableCrawlerInterface}</comment>,
+For crawlers implementing <comment>{$stoppableCrawler}</comment>,
 you can also configure the crawler to stop on failure. The <comment>--stop-on-failure</comment> option
 exists for this case:
 
@@ -453,7 +453,7 @@ HELP);
         $result = $this->timeTracker->track(
             fn () => $this->runCacheWarmup(
                 $cacheWarmer,
-                $crawler instanceof Crawler\VerboseCrawlerInterface,
+                $crawler instanceof Crawler\VerboseCrawler,
             ),
         );
 
@@ -498,7 +498,7 @@ HELP);
         return $result;
     }
 
-    private function initializeCacheWarmer(Crawler\CrawlerInterface $crawler): CacheWarmer
+    private function initializeCacheWarmer(Crawler\Crawler $crawler): CacheWarmer
     {
         if ($this->formatter->isVerbose()) {
             $this->io->write('Parsing sitemaps... ');
@@ -540,7 +540,7 @@ HELP);
         return $cacheWarmer;
     }
 
-    private function initializeCrawler(): Crawler\CrawlerInterface
+    private function initializeCrawler(): Crawler\Crawler
     {
         $crawler = $this->config->getCrawler();
         $crawlerOptions = $this->crawlerFactory->parseCrawlerOptions($this->config->getCrawlerOptions());
@@ -560,7 +560,7 @@ HELP);
         }
 
         // Print crawler options
-        if ($crawler instanceof Crawler\ConfigurableCrawlerInterface) {
+        if ($crawler instanceof Crawler\ConfigurableCrawler) {
             if ($this->formatter->isVerbose() && $this->io->isVerbose() && [] !== $crawlerOptions) {
                 $this->io->section('Using custom crawler options:');
                 $this->io->writeln((string) json_encode($crawlerOptions, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
@@ -574,7 +574,7 @@ HELP);
         }
 
         // Show notice on unsupported stoppable crawler feature
-        if ($stopOnFailure && !($crawler instanceof Crawler\StoppableCrawlerInterface)) {
+        if ($stopOnFailure && !($crawler instanceof Crawler\StoppableCrawler)) {
             $this->formatter->logMessage(
                 'You configured "stop on failure" for a non-stoppable crawler.',
                 Formatter\MessageSeverity::Warning,

--- a/src/Config/CacheWarmupConfig.php
+++ b/src/Config/CacheWarmupConfig.php
@@ -45,13 +45,13 @@ use function property_exists;
 final class CacheWarmupConfig
 {
     /**
-     * @param list<Sitemap\Sitemap>                                                $sitemaps
-     * @param list<Sitemap\Url>                                                    $urls
-     * @param list<Option\ExcludePattern>                                          $excludePatterns
-     * @param int<0, max>                                                          $limit
-     * @param Crawler\CrawlerInterface|class-string<Crawler\CrawlerInterface>|null $crawler
-     * @param array<string, mixed>                                                 $crawlerOptions
-     * @param int<0, max>                                                          $repeatAfter
+     * @param list<Sitemap\Sitemap>                              $sitemaps
+     * @param list<Sitemap\Url>                                  $urls
+     * @param list<Option\ExcludePattern>                        $excludePatterns
+     * @param int<0, max>                                        $limit
+     * @param Crawler\Crawler|class-string<Crawler\Crawler>|null $crawler
+     * @param array<string, mixed>                               $crawlerOptions
+     * @param int<0, max>                                        $repeatAfter
      */
     public function __construct(
         private array $sitemaps = [],
@@ -59,7 +59,7 @@ final class CacheWarmupConfig
         private array $excludePatterns = [],
         private int $limit = 0,
         private bool $progress = false,
-        private Crawler\CrawlerInterface|string|null $crawler = null,
+        private Crawler\Crawler|string|null $crawler = null,
         private array $crawlerOptions = [],
         private Crawler\Strategy\CrawlingStrategy|string|null $strategy = null,
         private string $format = 'text',
@@ -198,17 +198,17 @@ final class CacheWarmupConfig
     }
 
     /**
-     * @return Crawler\CrawlerInterface|class-string<Crawler\CrawlerInterface>|null
+     * @return Crawler\Crawler|class-string<Crawler\Crawler>|null
      */
-    public function getCrawler(): Crawler\CrawlerInterface|string|null
+    public function getCrawler(): Crawler\Crawler|string|null
     {
         return $this->crawler;
     }
 
     /**
-     * @param Crawler\CrawlerInterface|class-string<Crawler\CrawlerInterface> $crawler
+     * @param Crawler\Crawler|class-string<Crawler\Crawler> $crawler
      */
-    public function setCrawler(Crawler\CrawlerInterface|string $crawler): self
+    public function setCrawler(Crawler\Crawler|string $crawler): self
     {
         $this->crawler = $crawler;
 

--- a/src/Crawler/AbstractConfigurableCrawler.php
+++ b/src/Crawler/AbstractConfigurableCrawler.php
@@ -33,7 +33,7 @@ use Symfony\Component\OptionsResolver;
  *
  * @template TOptions of array<string, mixed>
  */
-abstract class AbstractConfigurableCrawler implements ConfigurableCrawlerInterface
+abstract class AbstractConfigurableCrawler implements ConfigurableCrawler
 {
     protected OptionsResolver\OptionsResolver $optionsResolver;
 

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -44,7 +44,7 @@ use Psr\Log;
  *     client_config: array<string, mixed>,
  * }>
  */
-final class ConcurrentCrawler extends AbstractConfigurableCrawler implements LoggingCrawlerInterface, StoppableCrawlerInterface
+final class ConcurrentCrawler extends AbstractConfigurableCrawler implements LoggingCrawler, StoppableCrawler
 {
     use ConcurrentCrawlerTrait;
 

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -73,8 +73,8 @@ trait ConcurrentCrawlerTrait
     }
 
     /**
-     * @param list<Message\UriInterface>                          $urls
-     * @param list<Http\Message\Handler\ResponseHandlerInterface> $handlers
+     * @param list<Message\UriInterface>                 $urls
+     * @param list<Http\Message\Handler\ResponseHandler> $handlers
      */
     protected function createPool(
         array $urls,

--- a/src/Crawler/ConfigurableCrawler.php
+++ b/src/Crawler/ConfigurableCrawler.php
@@ -23,20 +23,16 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
-use Psr\Log;
-
 /**
- * LoggingCrawlerInterface.
+ * ConfigurableCrawler.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface LoggingCrawlerInterface extends CrawlerInterface
+interface ConfigurableCrawler extends Crawler
 {
-    public function setLogger(Log\LoggerInterface $logger): void;
-
     /**
-     * @phpstan-param Log\LogLevel::* $logLevel
+     * @param array<string, mixed> $options
      */
-    public function setLogLevel(string $logLevel): void;
+    public function setOptions(array $options): void;
 }

--- a/src/Crawler/Crawler.php
+++ b/src/Crawler/Crawler.php
@@ -23,13 +23,19 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
+use EliasHaeussler\CacheWarmup\Result;
+use Psr\Http\Message;
+
 /**
- * StoppableCrawlerInterface.
+ * Crawler.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface StoppableCrawlerInterface extends CrawlerInterface
+interface Crawler
 {
-    public function stopOnFailure(bool $stopOnFailure = true): void;
+    /**
+     * @param list<Message\UriInterface> $urls
+     */
+    public function crawl(array $urls): Result\CacheWarmupResult;
 }

--- a/src/Crawler/CrawlerFactory.php
+++ b/src/Crawler/CrawlerFactory.php
@@ -52,31 +52,31 @@ final class CrawlerFactory
     ) {}
 
     /**
-     * @param class-string<CrawlerInterface> $crawler
-     * @param array<string, mixed>           $options
+     * @param class-string<Crawler> $crawler
+     * @param array<string, mixed>  $options
      *
      * @throws Exception\InvalidCrawlerException
      */
-    public function get(string $crawler, array $options = []): CrawlerInterface
+    public function get(string $crawler, array $options = []): Crawler
     {
         $this->validateCrawler($crawler);
 
         $crawler = new $crawler();
 
-        if ($crawler instanceof VerboseCrawlerInterface) {
+        if ($crawler instanceof VerboseCrawler) {
             $crawler->setOutput($this->output);
         }
 
-        if ($crawler instanceof ConfigurableCrawlerInterface) {
+        if ($crawler instanceof ConfigurableCrawler) {
             $crawler->setOptions($options);
         }
 
-        if ($crawler instanceof LoggingCrawlerInterface && null !== $this->logger) {
+        if ($crawler instanceof LoggingCrawler && null !== $this->logger) {
             $crawler->setLogger($this->logger);
             $crawler->setLogLevel($this->logLevel);
         }
 
-        if ($crawler instanceof StoppableCrawlerInterface) {
+        if ($crawler instanceof StoppableCrawler) {
             $crawler->stopOnFailure($this->stopOnFailure);
         }
 
@@ -127,7 +127,7 @@ final class CrawlerFactory
             throw Exception\InvalidCrawlerException::forMissingClass($crawler);
         }
 
-        if (!is_subclass_of($crawler, CrawlerInterface::class)) {
+        if (!is_subclass_of($crawler, Crawler::class)) {
             throw Exception\InvalidCrawlerException::forUnsupportedClass($crawler);
         }
     }

--- a/src/Crawler/LoggingCrawler.php
+++ b/src/Crawler/LoggingCrawler.php
@@ -23,19 +23,20 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
-use EliasHaeussler\CacheWarmup\Result;
-use Psr\Http\Message;
+use Psr\Log;
 
 /**
- * CrawlerInterface.
+ * LoggingCrawler.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface CrawlerInterface
+interface LoggingCrawler extends Crawler
 {
+    public function setLogger(Log\LoggerInterface $logger): void;
+
     /**
-     * @param list<Message\UriInterface> $urls
+     * @phpstan-param Log\LogLevel::* $logLevel
      */
-    public function crawl(array $urls): Result\CacheWarmupResult;
+    public function setLogLevel(string $logLevel): void;
 }

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -47,7 +47,7 @@ use function count;
  *     client_config: array<string, mixed>,
  * }>
  */
-final class OutputtingCrawler extends AbstractConfigurableCrawler implements LoggingCrawlerInterface, StoppableCrawlerInterface, VerboseCrawlerInterface
+final class OutputtingCrawler extends AbstractConfigurableCrawler implements LoggingCrawler, StoppableCrawler, VerboseCrawler
 {
     use ConcurrentCrawlerTrait;
 

--- a/src/Crawler/StoppableCrawler.php
+++ b/src/Crawler/StoppableCrawler.php
@@ -23,15 +23,13 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
-use Symfony\Component\Console;
-
 /**
- * VerboseCrawlerInterface.
+ * StoppableCrawler.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface VerboseCrawlerInterface extends CrawlerInterface
+interface StoppableCrawler extends Crawler
 {
-    public function setOutput(Console\Output\OutputInterface $output): void;
+    public function stopOnFailure(bool $stopOnFailure = true): void;
 }

--- a/src/Crawler/VerboseCrawler.php
+++ b/src/Crawler/VerboseCrawler.php
@@ -23,16 +23,15 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
+use Symfony\Component\Console;
+
 /**
- * ConfigurableCrawlerInterface.
+ * VerboseCrawler.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface ConfigurableCrawlerInterface extends CrawlerInterface
+interface VerboseCrawler extends Crawler
 {
-    /**
-     * @param array<string, mixed> $options
-     */
-    public function setOptions(array $options): void;
+    public function setOutput(Console\Output\OutputInterface $output): void;
 }

--- a/src/Exception/InvalidCrawlerOptionException.php
+++ b/src/Exception/InvalidCrawlerOptionException.php
@@ -37,7 +37,7 @@ use function sprintf;
  */
 final class InvalidCrawlerOptionException extends RuntimeException
 {
-    public static function create(Crawler\ConfigurableCrawlerInterface $crawler, string $option): self
+    public static function create(Crawler\ConfigurableCrawler $crawler, string $option): self
     {
         return new self(
             sprintf('The crawler option "%s" is invalid or not supported by crawler "%s".', $option, $crawler::class),

--- a/src/Http/Message/Handler/CompactProgressHandler.php
+++ b/src/Http/Message/Handler/CompactProgressHandler.php
@@ -33,7 +33,7 @@ use Throwable;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CompactProgressHandler implements ResponseHandlerInterface
+final class CompactProgressHandler implements ResponseHandler
 {
     private const PROGRESS_BAR_FORMAT = ' %current%/%max% [%bar%] %percent:3s%% -- <%fail_tag%>%fail_count% %failures%</>';
 

--- a/src/Http/Message/Handler/LogHandler.php
+++ b/src/Http/Message/Handler/LogHandler.php
@@ -35,7 +35,7 @@ use Throwable;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class LogHandler implements ResponseHandlerInterface
+final class LogHandler implements ResponseHandler
 {
     /**
      * @phpstan-param LogLevel::* $logLevel

--- a/src/Http/Message/Handler/ResponseHandler.php
+++ b/src/Http/Message/Handler/ResponseHandler.php
@@ -27,12 +27,12 @@ use Psr\Http\Message;
 use Throwable;
 
 /**
- * ResponseHandlerInterface.
+ * ResponseHandler.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-interface ResponseHandlerInterface
+interface ResponseHandler
 {
     public function onSuccess(Message\ResponseInterface $response, Message\UriInterface $uri): void;
 

--- a/src/Http/Message/Handler/ResultCollectorHandler.php
+++ b/src/Http/Message/Handler/ResultCollectorHandler.php
@@ -33,7 +33,7 @@ use Throwable;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class ResultCollectorHandler implements ResponseHandlerInterface
+final class ResultCollectorHandler implements ResponseHandler
 {
     private readonly Result\CacheWarmupResult $result;
 

--- a/src/Http/Message/Handler/VerboseProgressHandler.php
+++ b/src/Http/Message/Handler/VerboseProgressHandler.php
@@ -36,7 +36,7 @@ use function sprintf;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class VerboseProgressHandler implements ResponseHandlerInterface
+final class VerboseProgressHandler implements ResponseHandler
 {
     private readonly Console\Output\ConsoleSectionOutput $logSection;
     private readonly Console\Output\ConsoleSectionOutput $progressBarSection;

--- a/src/Http/Message/RequestPoolFactory.php
+++ b/src/Http/Message/RequestPoolFactory.php
@@ -50,7 +50,7 @@ final class RequestPoolFactory
     private array $options = [];
 
     /**
-     * @var list<Handler\ResponseHandlerInterface>
+     * @var list<Handler\ResponseHandler>
      */
     private array $handlers = [];
     private bool $stopOnFailure = false;
@@ -157,7 +157,7 @@ final class RequestPoolFactory
     /**
      * @phpstan-impure
      */
-    public function withResponseHandler(Handler\ResponseHandlerInterface ...$handler): self
+    public function withResponseHandler(Handler\ResponseHandler ...$handler): self
     {
         $clone = clone $this;
         $clone->handlers = [...$clone->handlers, ...array_values($handler)];

--- a/tests/src/Fixtures/Classes/DummyCrawler.php
+++ b/tests/src/Fixtures/Classes/DummyCrawler.php
@@ -37,7 +37,7 @@ use function array_shift;
  *
  * @internal
  */
-class DummyCrawler implements Crawler\CrawlerInterface
+class DummyCrawler implements Crawler\Crawler
 {
     /**
      * @var list<Message\UriInterface>

--- a/tests/src/Fixtures/Classes/DummyHandler.php
+++ b/tests/src/Fixtures/Classes/DummyHandler.php
@@ -35,7 +35,7 @@ use Throwable;
  *
  * @internal
  */
-final class DummyHandler implements Http\Message\Handler\ResponseHandlerInterface
+final class DummyHandler implements Http\Message\Handler\ResponseHandler
 {
     /**
      * @var list<Message\UriInterface>

--- a/tests/src/Fixtures/Classes/DummyLoggingCrawler.php
+++ b/tests/src/Fixtures/Classes/DummyLoggingCrawler.php
@@ -34,7 +34,7 @@ use Psr\Log;
  *
  * @internal
  */
-final class DummyLoggingCrawler extends DummyCrawler implements Crawler\LoggingCrawlerInterface
+final class DummyLoggingCrawler extends DummyCrawler implements Crawler\LoggingCrawler
 {
     public static ?Log\LoggerInterface $logger = null;
 

--- a/tests/src/Fixtures/Classes/DummyStoppableCrawler.php
+++ b/tests/src/Fixtures/Classes/DummyStoppableCrawler.php
@@ -33,7 +33,7 @@ use EliasHaeussler\CacheWarmup\Crawler;
  *
  * @internal
  */
-final class DummyStoppableCrawler extends DummyCrawler implements Crawler\StoppableCrawlerInterface
+final class DummyStoppableCrawler extends DummyCrawler implements Crawler\StoppableCrawler
 {
     public static bool $stopOnFailure = false;
 

--- a/tests/src/Fixtures/Classes/DummyVerboseCrawler.php
+++ b/tests/src/Fixtures/Classes/DummyVerboseCrawler.php
@@ -34,7 +34,7 @@ use Symfony\Component\Console;
  *
  * @internal
  */
-final class DummyVerboseCrawler extends DummyCrawler implements Crawler\VerboseCrawlerInterface
+final class DummyVerboseCrawler extends DummyCrawler implements Crawler\VerboseCrawler
 {
     public static ?Console\Output\OutputInterface $output = null;
 


### PR DESCRIPTION
This PR drops the `Interface` class name suffix from all interfaces.