### PR TITLE
[TASK] Increase verbosity to display parsed sitemaps

### DIFF
--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -56,7 +56,7 @@ final class TextFormatter implements Formatter
         $urlsShown = false;
 
         // Add successful sitemaps
-        if ($this->io->isVerbose()) {
+        if ($this->io->isVeryVerbose()) {
             foreach ($successful->getSitemaps() as $successfulSitemap) {
                 $sitemaps[] = sprintf('<success> DONE </> <href=%1$s>%1$s</>', (string) $successfulSitemap->getUri());
             }

--- a/tests/src/Formatter/TextFormatterTest.php
+++ b/tests/src/Formatter/TextFormatterTest.php
@@ -62,9 +62,9 @@ final class TextFormatterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function formatParserResultPrintsSuccessfulSitemapsIfOutputIsVerbose(): void
+    public function formatParserResultPrintsSuccessfulSitemapsIfOutputIsVeryVerbose(): void
     {
-        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERBOSE);
+        $this->output->setVerbosity(Console\Output\OutputInterface::VERBOSITY_VERY_VERBOSE);
 
         $url = 'https://www.example.com';
         $successful = new Src\Result\ParserResult(


### PR DESCRIPTION
This PR increases verbosity to display parsed sitemaps with the `text` formatter. Sitemaps are now displayed with at least very verbose output.