### PR TITLE
[DOCS] Generate XML sitemap for documentation

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,9 @@ export default defineConfig({
     head: [
         ['link', {rel: 'icon', href: '/favicon.ico'}],
     ],
+    sitemap: {
+        hostname: 'https://cache-warmup.haeussler.dev',
+    },
     themeConfig: {
         logo: '/img/logo.svg',
         nav: [


### PR DESCRIPTION
This PR configures VitePress to build an XML sitemap for the documentation.