### PR TITLE
[DOCS] Resolve paths outside of srcDir to repo blob urls

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,12 +1,25 @@
 import {defineConfig} from 'vitepress';
 // @ts-ignore
+import markdownItReplaceLink from 'markdown-it-replace-link';
+// @ts-ignore
+import path from 'path';
+// @ts-ignore
+import {RepoLinkReplacer} from './repo-link-replacer.mts';
+// @ts-ignore
 import {version} from '../../package.json';
 
+// General information
 const hostname: string = 'https://cache-warmup.dev';
 const title: string = 'Cache Warmup';
 const description: string = 'Library to warm up website caches of URLs located in XML sitemaps. Highly customizable and written in PHP.';
 const image: string = `${hostname}/img/social-media.png`;
 const imageAltText: string = 'Screenshot from a terminal window running the "cache-warmup" command on the XML sitemap from Google.';
+
+// GitHub repository
+const repoUrl: string = 'https://github.com/eliashaeussler/cache-warmup';
+// @ts-ignore
+const rootPath: string = path.resolve(__dirname, '..');
+const replacer = new RepoLinkReplacer(repoUrl, rootPath);
 
 export default defineConfig({
     title: title,
@@ -43,12 +56,12 @@ export default defineConfig({
                 items: [
                     {
                         text: 'Release Notes',
-                        link: 'https://github.com/eliashaeussler/cache-warmup/releases/latest',
+                        link: `${repoUrl}/releases/latest`,
                         rel: 'nofollow',
                     },
                     {
                         text: 'Download',
-                        link: 'https://github.com/eliashaeussler/cache-warmup/releases/latest/download/cache-warmup.phar',
+                        link: `${repoUrl}/releases/latest/download/cache-warmup.phar`,
                         rel: 'nofollow',
                     },
                 ],
@@ -143,10 +156,10 @@ export default defineConfig({
             },
         ],
         socialLinks: [
-            {icon: 'github', link: 'https://github.com/eliashaeussler/cache-warmup'},
+            {icon: 'github', link: repoUrl},
         ],
         editLink: {
-            pattern: 'https://github.com/eliashaeussler/cache-warmup/edit/main/docs/:path',
+            pattern: `${repoUrl}/edit/main/docs/:path`,
         },
         footer: {
             message: 'Released under the GNU General Public License 3.0 (or later)',
@@ -154,6 +167,13 @@ export default defineConfig({
         },
         search: {
             provider: 'local',
+        },
+    },
+    markdown: {
+        preConfig: (md) => {
+            md.use(markdownItReplaceLink, {
+                replaceLink: (link, {relativePath}) => replacer.replaceLink(link, relativePath),
+            });
         },
     },
 });

--- a/docs/.vitepress/repo-link-replacer.mts
+++ b/docs/.vitepress/repo-link-replacer.mts
@@ -1,0 +1,33 @@
+// @ts-ignore
+import path from 'path';
+
+export class RepoLinkReplacer
+{
+    constructor(
+        private readonly repoUrl: string,
+        private readonly rootPath: string,
+    ) {}
+
+    public replaceLink(link: string, templatePath: string): string
+    {
+        if (!link.startsWith('../') || link.includes('#')) {
+            return link;
+        }
+
+        const fullTemplatePath = path.resolve(this.rootPath, templatePath);
+        const fullTargetPath = path.resolve(path.dirname(fullTemplatePath), link);
+        const relativePath = path.relative(this.rootPath, fullTargetPath);
+
+        if (!relativePath.startsWith('../')) {
+            return link;
+        }
+
+        const blobUrl = `${this.repoUrl}/blob/main/${relativePath.substring(3)}`;
+
+        if (process.env.NODE_ENV !== 'production') {
+            console.log(`Replaced link: ${link} → ${blobUrl}`);
+        }
+
+        return blobUrl;
+    }
+}

--- a/docs/api/configurable-crawler.md
+++ b/docs/api/configurable-crawler.md
@@ -6,7 +6,7 @@ outline: [2,3]
 
 Whenever you want to allow a custom behavior of your crawler, it
 should implement
-[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConfigurableCrawler.php):
+[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`](../../src/Crawler/ConfigurableCrawler.php):
 
 ```php
 namespace Vendor\Crawler;

--- a/docs/api/crawler.md
+++ b/docs/api/crawler.md
@@ -7,7 +7,7 @@ outline: [2,3]
 Crawlers are the core component of the library. They are used
 to perform the actual requests for all configured URLs to warm
 up their website caches. Each crawler must implement
-[`EliasHaeussler\CacheWarmup\Crawler\Crawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/Crawler.php):
+[`EliasHaeussler\CacheWarmup\Crawler\Crawler`](../../src/Crawler/Crawler.php):
 
 ```php
 namespace Vendor\Crawler;

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -12,7 +12,7 @@ the whole set of available [configuration options](../config-reference/index.md)
 
 ## `CacheWarmer`
 
-The [`EliasHaeussler\CacheWarmup\CacheWarmer`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/CacheWarmer.php)
+The [`EliasHaeussler\CacheWarmup\CacheWarmer`](../../src/CacheWarmer.php)
 class serves as main entrypoint for the PHP API.
 
 ```php
@@ -35,7 +35,7 @@ opportunities.
 ## `Crawler`
 
 URLs in XML sitemaps are processed by crawlers implementing
-[`EliasHaeussler\CacheWarmup\Crawler\Crawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/Crawler.php).
+[`EliasHaeussler\CacheWarmup\Crawler\Crawler`](../../src/Crawler/Crawler.php).
 Read more about how to [create a custom crawler](crawler.md).
 
 In addition, there exist different variations of crawler
@@ -61,8 +61,8 @@ Enhances the cache warmup process with user-oriented output.
 
 The library ships with two default crawlers:
 
-* [`EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConcurrentCrawler.php)
-* [`EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/OutputtingCrawler.php)
+* [`EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler`](../../src/Crawler/ConcurrentCrawler.php)
+* [`EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler`](../../src/Crawler/OutputtingCrawler.php)
 
 You can find all available crawler options in the
 [`crawlerOptions`](../config-reference/crawler-options.md#option-reference)

--- a/docs/api/logging-crawler.md
+++ b/docs/api/logging-crawler.md
@@ -6,7 +6,7 @@ outline: [2,3]
 
 In some cases it might be helpful to log parts of the cache
 warmup process. For this, your crawler should implement
-[`EliasHaeussler\CacheWarmup\Crawler\LoggingCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/LoggingCrawler.php):
+[`EliasHaeussler\CacheWarmup\Crawler\LoggingCrawler`](../../src/Crawler/LoggingCrawler.php):
 
 ```php
 namespace Vendor\Crawler;

--- a/docs/api/methods.md
+++ b/docs/api/methods.md
@@ -17,7 +17,7 @@ $result = $cacheWarmer->run();
 ```
 
 Once cache warmup is finished, this method returns an instance of
-[`EliasHaeussler\CacheWarmup\Result\CacheWarmupResult`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Result/CacheWarmupResult.php)
+[`EliasHaeussler\CacheWarmup\Result\CacheWarmupResult`](../../src/Result/CacheWarmupResult.php)
 with all successful and failed crawling results:
 
 ```php

--- a/docs/api/stoppable-crawler.md
+++ b/docs/api/stoppable-crawler.md
@@ -6,7 +6,7 @@ outline: [2,3]
 
 In terms of error handling it might be useful to define the
 behavior in case a cache warmup failure occurs. You can implement
-[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/StoppableCrawler.php)
+[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawler`](../../src/Crawler/StoppableCrawler.php)
 to make this sort of error handling configurable:
 
 ```php

--- a/docs/api/verbose-crawler.md
+++ b/docs/api/verbose-crawler.md
@@ -7,7 +7,7 @@ outline: [2,3]
 When cache warmup is performed from the command line, it might
 be helpful to provide user-oriented output such as progress bars
 or error messages. In this case, you can implement
-[`EliasHaeussler\CacheWarmup\Crawler\VerboseCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/VerboseCrawler.php):
+[`EliasHaeussler\CacheWarmup\Crawler\VerboseCrawler`](../../src/Crawler/VerboseCrawler.php):
 
 ```php
 namespace Vendor\Crawler;

--- a/docs/config-reference/crawler-options.md
+++ b/docs/config-reference/crawler-options.md
@@ -10,7 +10,7 @@ outline: [2,3]
 
 ::: info
 These options only apply to crawlers implementing
-[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConfigurableCrawler.php).
+[`EliasHaeussler\CacheWarmup\Crawler\ConfigurableCrawler`](../../src/Crawler/ConfigurableCrawler.php).
 If the configured crawler does not implement this interface, a warning is
 shown in case crawler options are configured.
 :::
@@ -71,8 +71,8 @@ CACHE_WARMUP_CRAWLER_OPTIONS='{"concurrency": 3, "request_options": {"delay": 30
 
 Both default crawlers are implemented as configurable crawlers:
 
-* [`EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConcurrentCrawler.php)
-* [`EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/OutputtingCrawler.php)
+* [`EliasHaeussler\CacheWarmup\Crawler\ConcurrentCrawler`](../../src/Crawler/ConcurrentCrawler.php)
+* [`EliasHaeussler\CacheWarmup\Crawler\OutputtingCrawler`](../../src/Crawler/OutputtingCrawler.php)
 
 The following configuration options are currently available for both crawlers:
 
@@ -116,7 +116,7 @@ return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
 Internally, Guzzle's [Pool](https://docs.guzzlephp.org/en/stable/quickstart.html#concurrent-requests)
 feature is used to send multiple requests  concurrently using asynchronous
 requests. You may also have a look at how  this is implemented in the library's
-[`RequestPoolFactory`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Http/Message/RequestPoolFactory.php).
+[`RequestPoolFactory`](../../src/Http/Message/RequestPoolFactory.php).
 :::
 
 ::: code-group
@@ -163,7 +163,7 @@ CACHE_WARMUP_CRAWLER_OPTIONS='{"concurrency": 5}'
 
 ::: info
 The default User-Agent is built in
-[`ConcurrentCrawlerTrait::getRequestHeaders()`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConcurrentCrawlerTrait.php).
+[`ConcurrentCrawlerTrait::getRequestHeaders()`](../../src/Crawler/ConcurrentCrawlerTrait.php).
 :::
 
 ::: code-group

--- a/docs/config-reference/crawler.md
+++ b/docs/config-reference/crawler.md
@@ -7,9 +7,9 @@
 ::: info
 The default crawler depends on whether the configuration option
 [`progress`](progress.md) is set. In this case the
-[`OutputtingCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/OutputtingCrawler.php)
+[`OutputtingCrawler`](../../src/Crawler/OutputtingCrawler.php)
 is used, otherwise the
-[`ConcurrentCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/ConcurrentCrawler.php).
+[`ConcurrentCrawler`](../../src/Crawler/ConcurrentCrawler.php).
 :::
 
 ::: tip

--- a/docs/config-reference/format.md
+++ b/docs/config-reference/format.md
@@ -53,7 +53,7 @@ The resulting JSON object includes the following properties:
 | `time`              | Lists all tracked times during cache warmup (`crawl`, `parse`)                                                         |
 
 The complete JSON structure can be found in the provided
-[JSON schema](https://github.com/eliashaeussler/cache-warmup/blob/main/res/cache-warmup-result.schema.json).
+[JSON schema](../../res/cache-warmup-result.schema.json).
 
 
 ## Text formatter: `text`

--- a/docs/config-reference/stop-on-failure.md
+++ b/docs/config-reference/stop-on-failure.md
@@ -6,7 +6,7 @@
 
 ::: info
 This option only apply to crawlers implementing
-[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawler`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Crawler/StoppableCrawler.php).
+[`EliasHaeussler\CacheWarmup\Crawler\StoppableCrawler`](../../src/Crawler/StoppableCrawler.php).
 If the configured crawler does not implement this interface, a warning is
 shown in case this flag is enabled.
 :::

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,7 +58,7 @@ exclude:
 
 PHP configuration files must return a closure which receives the
 current instance of
-[`EliasHaeussler\CacheWarmup\Config\CacheWarmupConfig`](https://github.com/eliashaeussler/cache-warmup/blob/main/src/Config/CacheWarmupConfig.php).
+[`EliasHaeussler\CacheWarmup\Config\CacheWarmupConfig`](../src/Config/CacheWarmupConfig.php).
 They may also return a (new) instance to override the current one:
 
 ```php

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -78,5 +78,5 @@ the problem you're trying to solve.
 
 All described code quality tools are automatically executed on each pull request
 for all currently supported PHP versions. Take a look at the appropriate
-[workflows](https://github.com/eliashaeussler/cache-warmup/tree/main/.github/workflows)
+[workflows](../.github/workflows)
 to get a detailed overview.

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
 			"version": "3.0.1",
 			"license": "GPL-3.0-or-later",
 			"devDependencies": {
+				"@types/node": "^20.12.7",
 				"depcheck": "^1.4.7",
+				"markdown-it-replace-link": "^1.2.1",
 				"vitepress": "^1.0.0"
 			}
 		},
@@ -1095,6 +1097,15 @@
 			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
 			"dev": true
 		},
+		"node_modules/@types/node": {
+			"version": "20.12.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
+			"integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+			"dev": true,
+			"dependencies": {
+				"undici-types": "~5.26.4"
+			}
+		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.2",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
@@ -1707,6 +1718,65 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/dom-serializer": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+			"integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.2",
+				"entities": "^4.2.0"
+			},
+			"funding": {
+				"url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+			}
+		},
+		"node_modules/domelementtype": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+			"integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"optional": true
+		},
+		"node_modules/domhandler": {
+			"version": "5.0.3",
+			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+			"integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0"
+			},
+			"engines": {
+				"node": ">= 4"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domhandler?sponsor=1"
+			}
+		},
+		"node_modules/domutils": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+			"integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+			"dev": true,
+			"optional": true,
+			"dependencies": {
+				"dom-serializer": "^2.0.0",
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/domutils?sponsor=1"
+			}
+		},
 		"node_modules/emoji-regex": {
 			"version": "8.0.0",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -1967,6 +2037,26 @@
 			"integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
 			"dev": true
 		},
+		"node_modules/htmlparser2": {
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-8.0.2.tgz",
+			"integrity": "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==",
+			"dev": true,
+			"funding": [
+				"https://github.com/fb55/htmlparser2?sponsor=1",
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/fb55"
+				}
+			],
+			"optional": true,
+			"dependencies": {
+				"domelementtype": "^2.3.0",
+				"domhandler": "^5.0.3",
+				"domutils": "^3.0.1",
+				"entities": "^4.4.0"
+			}
+		},
 		"node_modules/ignore": {
 			"version": "5.3.1",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -2134,6 +2224,16 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true
 		},
+		"node_modules/linkify-it": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+			"integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
+		},
 		"node_modules/lodash": {
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2166,6 +2266,52 @@
 			"resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
 			"integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
 			"dev": true
+		},
+		"node_modules/markdown-it": {
+			"version": "14.1.0",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+			"integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+			"dev": true,
+			"peer": true,
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdown-it-replace-link": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/markdown-it-replace-link/-/markdown-it-replace-link-1.2.1.tgz",
+			"integrity": "sha512-pRcJ1Gym1bwTqAJDB5n3JurF02aDRa5B+Jlvwg9zdBGza0zH7LJWxu2jD5mnTdt2LoSyuvqw+AgzTe5IVEWIYQ==",
+			"dev": true,
+			"optionalDependencies": {
+				"dom-serializer": "^2.0.0",
+				"htmlparser2": "^8.0.1"
+			},
+			"peerDependencies": {
+				"@types/markdown-it": "*",
+				"markdown-it": "*"
+			}
+		},
+		"node_modules/markdown-it/node_modules/argparse": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"peer": true
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.5",
@@ -2395,6 +2541,16 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/preact"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+			"dev": true,
+			"peer": true,
+			"engines": {
+				"node": ">=6"
 			}
 		},
 		"node_modules/readdirp": {
@@ -2641,6 +2797,19 @@
 			"engines": {
 				"node": ">=8.0"
 			}
+		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"peer": true
+		},
+		"node_modules/undici-types": {
+			"version": "5.26.5",
+			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+			"integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+			"dev": true
 		},
 		"node_modules/vite": {
 			"version": "5.2.9",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
 	},
 	"homepage": "https://cache-warmup.dev/",
 	"devDependencies": {
+		"@types/node": "^20.12.7",
 		"depcheck": "^1.4.7",
+		"markdown-it-replace-link": "^1.2.1",
 		"vitepress": "^1.0.0"
 	},
 	"scripts": {


### PR DESCRIPTION
This PR adds an additional handler to resolve links to files outside of the `srcDir` to GitHub repository blob URLs. This way, it is no longer necessary to write a bunch of blob URLs into Markdown files. It also enables better interoperability of raw Markdown files inside GitHub UI.