### PR TITLE
[FEATURE] Provide config method to explicitly disable endless mode

### DIFF
--- a/src/Config/CacheWarmupConfig.php
+++ b/src/Config/CacheWarmupConfig.php
@@ -361,6 +361,13 @@ final class CacheWarmupConfig
         return $this;
     }
 
+    public function disableEndlessMode(): self
+    {
+        $this->repeatAfter = 0;
+
+        return $this;
+    }
+
     public function merge(self $other): self
     {
         $parameters = $this->toArray(true);

--- a/tests/src/Config/CacheWarmupConfigTest.php
+++ b/tests/src/Config/CacheWarmupConfigTest.php
@@ -159,6 +159,14 @@ final class CacheWarmupConfigTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function disableEndlessModeSetsEndlessModeToZero(): void
+    {
+        $this->subject->disableEndlessMode();
+
+        self::assertSame(0, $this->subject->getRepeatAfter());
+    }
+
+    #[Framework\Attributes\Test]
     public function mergeMergesGivenConfigIntoCurrentConfigObject(): void
     {
         $other = new Src\Config\CacheWarmupConfig(


### PR DESCRIPTION
This PR adds a new `disableEndlessMode()` method to the config class. It allows to explicitly disable endless mode, which is equivalent to calling `setRepeatAfter(0)`.