### PR TITLE
[TASK] Run cache warmup after documentation deployment

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,6 +33,11 @@ jobs:
         with:
           node-version: 20
           cache: npm
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.3
+          coverage: none
       - name: Setup Pages
         uses: actions/configure-pages@v5
 
@@ -52,3 +57,11 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+      # Warm up cache
+      - name: Run cache warmup
+        uses: eliashaeussler/cache-warmup-action@v1
+        with:
+          sitemaps: ${{ steps.deployment.outputs.page_url }}/sitemap.xml
+          progress: true
+          verbosity: v


### PR DESCRIPTION
This PR adds an additional step to the documentation deployment which warms up caches of the rendered documentation. This is more an example showcase to demonstrate the library's features, because it's actually not necessary to warm up the static pages.