### PR TITLE
[BUGFIX] Support `<lastmod>` with milliseconds

### DIFF
--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -158,6 +158,7 @@ final class XmlParser
             )
             ->supportDateFormats(
                 DateTimeInterface::W3C,
+                'Y-m-d\TH:i:s.v\Z',
                 '!Y-m-d',
             )
             ->mapper()

--- a/tests/unit/Fixtures/Sitemaps/valid_sitemap_5.xml
+++ b/tests/unit/Fixtures/Sitemaps/valid_sitemap_5.xml
@@ -9,7 +9,7 @@
     <url>
         <loc>https://www.example.org/foo</loc>
         <priority>0.5</priority>
-        <lastmod>2021-06-07T20:01:25+02:00</lastmod>
+        <lastmod>2021-06-07T20:01:25.000Z</lastmod>
         <changefreq>monthly</changefreq>
     </url>
     <url>

--- a/tests/unit/Mapper/Source/XmlSourceTest.php
+++ b/tests/unit/Mapper/Source/XmlSourceTest.php
@@ -65,7 +65,7 @@ final class XmlSourceTest extends Framework\TestCase
                 [
                     'loc' => 'https://www.example.org/foo',
                     'priority' => '0.5',
-                    'lastmod' => '2021-06-07T20:01:25+02:00',
+                    'lastmod' => '2021-06-07T20:01:25.000Z',
                     'changefreq' => 'monthly',
                 ],
                 [

--- a/tests/unit/Xml/XmlParserTest.php
+++ b/tests/unit/Xml/XmlParserTest.php
@@ -90,7 +90,7 @@ final class XmlParserTest extends Framework\TestCase
             new Src\Sitemap\Url(
                 uri: 'https://www.example.org/foo',
                 priority: 0.5,
-                lastModificationDate: new DateTimeImmutable('2021-06-07T20:01:25+02:00'),
+                lastModificationDate: new DateTimeImmutable('2021-06-07T20:01:25+00:00'),
                 changeFrequency: Src\Sitemap\ChangeFrequency::Monthly,
                 origin: $this->sitemap,
             ),


### PR DESCRIPTION
This PR adds support for `<lastmod>` values with milliseconds, e.g. `2021-06-07T20:01:25.000Z`.