### PR TITLE
[BUGFIX] Use custom URI syntax to handle local files as XML sitemaps

### DIFF
--- a/src/CacheWarmer.php
+++ b/src/CacheWarmer.php
@@ -98,9 +98,10 @@ final class CacheWarmer
      * @param list<string|Sitemap\Sitemap>|string|Sitemap\Sitemap $sitemaps
      *
      * @throws Exception\FileIsMissing
+     * @throws Exception\LocalFilePathIsMissingInUrl
+     * @throws Exception\SitemapCannotBeParsed
      * @throws Exception\SitemapIsInvalid
      * @throws Exception\UrlIsEmpty
-     * @throws Exception\SitemapCannotBeParsed
      * @throws Exception\UrlIsInvalid
      * @throws GuzzleException
      * @throws ValinorXml\Exception\ArrayPathHasUnexpectedType
@@ -141,7 +142,7 @@ final class CacheWarmer
             // Parse sitemap object
             try {
                 $result = $this->parser->parse($sitemap);
-            } catch (GuzzleException|Exception\FileIsMissing|Exception\SitemapCannotBeParsed|ValinorXml\Exception\Exception $exception) {
+            } catch (GuzzleException|Exception\FileIsMissing|Exception\SitemapCannotBeParsed|Exception\UrlIsInvalid|ValinorXml\Exception\Exception $exception) {
                 // Exit early if running in strict mode
                 if ($this->strict) {
                     throw $exception;

--- a/src/Exception/LocalFilePathIsMissingInUrl.php
+++ b/src/Exception/LocalFilePathIsMissingInUrl.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Exception;
+
+use function sprintf;
+
+/**
+ * LocalFilePathIsMissingInUrl.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class LocalFilePathIsMissingInUrl extends Exception
+{
+    public function __construct(string $url)
+    {
+        parent::__construct(
+            sprintf('The given URL "%s" does not provide a local file path.', $url),
+            1718982288,
+        );
+    }
+}

--- a/src/Helper/FilesystemHelper.php
+++ b/src/Helper/FilesystemHelper.php
@@ -26,6 +26,10 @@ namespace EliasHaeussler\CacheWarmup\Helper;
 use EliasHaeussler\CacheWarmup\Exception;
 use Symfony\Component\Filesystem;
 
+use function implode;
+use function preg_replace;
+use function rtrim;
+
 /**
  * FilesystemHelper.
  *
@@ -40,7 +44,9 @@ final class FilesystemHelper
             return $relativePath;
         }
 
-        return Filesystem\Path::makeAbsolute($relativePath, self::getWorkingDirectory());
+        return self::joinPathSegments(
+            Filesystem\Path::makeAbsolute($relativePath, self::getWorkingDirectory()),
+        );
     }
 
     public static function getWorkingDirectory(): string
@@ -51,6 +57,20 @@ final class FilesystemHelper
             throw new Exception\WorkingDirectoryCannotBeResolved();
         }
 
-        return Filesystem\Path::canonicalize($cwd);
+        return self::joinPathSegments(
+            Filesystem\Path::canonicalize($cwd),
+        );
+    }
+
+    public static function joinPathSegments(string ...$pathSegments): string
+    {
+        return rtrim(
+            (string) preg_replace(
+                '#[/\\\]+#',
+                DIRECTORY_SEPARATOR,
+                implode(DIRECTORY_SEPARATOR, $pathSegments),
+            ),
+            '/\\',
+        );
     }
 }

--- a/src/Xml/XmlParser.php
+++ b/src/Xml/XmlParser.php
@@ -39,8 +39,6 @@ use Throwable;
 use function file_exists;
 use function file_get_contents;
 use function is_readable;
-use function str_starts_with;
-use function substr;
 
 /**
  * XmlParser.
@@ -61,6 +59,7 @@ final class XmlParser
     /**
      * @throws Exception\FileIsMissing
      * @throws Exception\SitemapCannotBeParsed
+     * @throws Exception\UrlIsInvalid
      * @throws GuzzleException
      * @throws ValinorXml\Exception\ArrayPathHasUnexpectedType
      * @throws ValinorXml\Exception\ArrayPathIsInvalid
@@ -71,8 +70,8 @@ final class XmlParser
         $uri = $sitemap->getUri();
 
         // Fetch XML source
-        if (str_starts_with((string) $uri, 'file://')) {
-            $contents = $this->fetchLocalFile($uri);
+        if ($sitemap->isLocalFile()) {
+            $contents = $this->fetchLocalFile($sitemap->getLocalFilePath());
         } else {
             $contents = $this->fetchUrl($uri);
         }
@@ -117,11 +116,8 @@ final class XmlParser
     /**
      * @throws Exception\FileIsMissing
      */
-    private function fetchLocalFile(Message\UriInterface $uri): string
+    private function fetchLocalFile(string $filename): string
     {
-        // Remove file:// prefix
-        $filename = substr((string) $uri, 7);
-
         if (!file_exists($filename) || !is_readable($filename)) {
             throw new Exception\FileIsMissing($filename);
         }

--- a/tests/unit/CacheWarmerTest.php
+++ b/tests/unit/CacheWarmerTest.php
@@ -286,8 +286,8 @@ final class CacheWarmerTest extends Framework\TestCase
         $origin2 = new Src\Sitemap\Sitemap(new Psr7\Uri('https://www.example.com/sitemap.xml'));
         $origin3 = new Src\Sitemap\Sitemap(new Psr7\Uri('https://www.example.org/sitemap_en.xml'), origin: $origin2);
 
-        $localFile = __DIR__.'/Fixtures/Sitemaps/valid_sitemap_2.xml';
-        $originLocal = new Src\Sitemap\Sitemap(new Psr7\Uri('file://'.$localFile));
+        $localFile = Src\Helper\FilesystemHelper::joinPathSegments(__DIR__.'/Fixtures/Sitemaps/valid_sitemap_2.xml');
+        $originLocal = Src\Sitemap\Sitemap::createFromString($localFile);
 
         yield 'empty sitemaps' => [
             [],

--- a/tests/unit/Exception/LocalFilePathIsMissingInUrlTest.php
+++ b/tests/unit/Exception/LocalFilePathIsMissingInUrlTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Exception;
+
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
+
+/**
+ * LocalFilePathIsMissingInUrlTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Exception\LocalFilePathIsMissingInUrl::class)]
+final class LocalFilePathIsMissingInUrlTest extends Framework\TestCase
+{
+    #[Framework\Attributes\Test]
+    public function constructorCreatesExceptionIfLocalFilePathIsMissing(): void
+    {
+        $actual = new Src\Exception\LocalFilePathIsMissingInUrl('local://file');
+
+        self::assertSame(1718982288, $actual->getCode());
+        self::assertSame('The given URL "local://file" does not provide a local file path.', $actual->getMessage());
+    }
+}

--- a/tests/unit/Helper/FilesystemHelperTest.php
+++ b/tests/unit/Helper/FilesystemHelperTest.php
@@ -24,7 +24,10 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Helper;
 
 use EliasHaeussler\CacheWarmup as Src;
+use Generator;
 use PHPUnit\Framework;
+
+use function implode;
 
 /**
  * FilesystemHelperTest.
@@ -69,5 +72,30 @@ final class FilesystemHelperTest extends Framework\TestCase
         self::assertSame(__DIR__, Src\Helper\FilesystemHelper::getWorkingDirectory());
 
         chdir($cwd);
+    }
+
+    /**
+     * @param list<string> $pathSegments
+     */
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('joinPathSegmentsMergesGivenPathSegmentsWithGlobalDirectorySeparatorDataProvider')]
+    public function joinPathSegmentsMergesGivenPathSegmentsWithGlobalDirectorySeparator(
+        array $pathSegments,
+        string $expected,
+    ): void {
+        self::assertSame($expected, Src\Helper\FilesystemHelper::joinPathSegments(...$pathSegments));
+    }
+
+    /**
+     * @return Generator<string, array{list<string>, string}>
+     */
+    public static function joinPathSegmentsMergesGivenPathSegmentsWithGlobalDirectorySeparatorDataProvider(): Generator
+    {
+        $expected = DIRECTORY_SEPARATOR.implode(DIRECTORY_SEPARATOR, ['foo', 'baz']);
+
+        yield 'no path segments' => [[], ''];
+        yield 'single path segment' => [['/foo/baz'], $expected];
+        yield 'multiple path segments' => [['/foo', 'baz'], $expected];
+        yield 'with empty path segments' => [['/foo', '', 'baz', ''], $expected];
     }
 }

--- a/tests/unit/Xml/XmlParserTest.php
+++ b/tests/unit/Xml/XmlParserTest.php
@@ -171,8 +171,10 @@ final class XmlParserTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function parseParsesLocalFile(): void
     {
-        $filename = dirname(__DIR__).'/Fixtures/Sitemaps/valid_sitemap_4.xml';
-        $sitemap = new Src\Sitemap\Sitemap(new Psr7\Uri('file://'.$filename));
+        $filename = Src\Helper\FilesystemHelper::joinPathSegments(
+            dirname(__DIR__).'/Fixtures/Sitemaps/valid_sitemap_4.xml',
+        );
+        $sitemap = Src\Sitemap\Sitemap::createFromString($filename);
 
         $result = $this->subject->parse($sitemap);
 
@@ -190,7 +192,7 @@ final class XmlParserTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function parseThrowsExceptionOnMissingLocalFile(): void
     {
-        $sitemap = new Src\Sitemap\Sitemap(new Psr7\Uri('file:///foo'));
+        $sitemap = Src\Sitemap\Sitemap::createFromString('/foo');
 
         $this->expectException(Src\Exception\FileIsMissing::class);
         $this->expectExceptionCode(1698427082);


### PR DESCRIPTION
This PR fixes an issue with local file paths for XML sitemaps on Windows systems. For this, a new syntax was introduced to reference local files using the `Sitemap` object.

```diff
-file:///path/to/sitemap.xml
+local://file?path=%2Fpath%2Fto%2Fsitemap.xml
```