### PR TITLE
[TASK] Provide current library version as CacheWarmer::VERSION constant

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,4 @@
 /phpunit.xml              export-ignore
 /rector.php               export-ignore
 /renovate.json            export-ignore
+/version-bumper.yaml      export-ignore

--- a/bin/cache-warmup
+++ b/bin/cache-warmup
@@ -22,8 +22,8 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
+use EliasHaeussler\CacheWarmup\CacheWarmer;
 use EliasHaeussler\CacheWarmup\Command;
-use EliasHaeussler\CacheWarmup\Helper;
 use Symfony\Component\Console;
 
 // Check Composer autoloader
@@ -46,7 +46,7 @@ unset($autoloadFile, $file);
 
 // Run application
 $command = new Command\CacheWarmupCommand();
-$application = new Console\Application('cache-warmup', Helper\VersionHelper::getCurrentVersion() ?? 'UNKNOWN');
+$application = new Console\Application('cache-warmup', CacheWarmer::VERSION);
 $application->add($command);
 $application->setDefaultCommand('cache-warmup', true);
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,6 @@
 		"ext-json": "*",
 		"ext-mbstring": "*",
 		"ext-zlib": "*",
-		"composer-runtime-api": "^2.1",
 		"cuyz/valinor": "^1.3",
 		"eliashaeussler/valinor-xml": "^1.0",
 		"guzzlehttp/guzzle": "^7.0",
@@ -37,6 +36,7 @@
 		"eliashaeussler/phpstan-config": "^2.0",
 		"eliashaeussler/rector-config": "^3.0",
 		"eliashaeussler/transient-logger": "^1.0",
+		"eliashaeussler/version-bumper": "^1.0",
 		"ergebnis/composer-normalize": "^2.28",
 		"phpstan/extension-installer": "^1.2",
 		"phpstan/phpstan-phpunit": "^1.1",
@@ -58,6 +58,7 @@
 	],
 	"config": {
 		"allow-plugins": {
+			"eliashaeussler/version-bumper": true,
 			"ergebnis/composer-normalize": true,
 			"phpstan/extension-installer": true
 		},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ba2528a9073285c5fc4c5f3b1166fcbb",
+    "content-hash": "65110a7aa2962ec0ddbcfa4254de0ae7",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -2299,6 +2299,68 @@
                 "source": "https://github.com/eliashaeussler/transient-logger/tree/1.0.0"
             },
             "time": "2023-11-23T09:41:00+00:00"
+        },
+        {
+            "name": "eliashaeussler/version-bumper",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/eliashaeussler/version-bumper.git",
+                "reference": "24203510b5667d35cc6cfe3f3266316cc763fe5e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/eliashaeussler/version-bumper/zipball/24203510b5667d35cc6cfe3f3266316cc763fe5e",
+                "reference": "24203510b5667d35cc6cfe3f3266316cc763fe5e",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0",
+                "cuyz/valinor": "^1.0",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
+                "symfony/console": "^5.4 || ^6.4 || ^7.0",
+                "symfony/filesystem": "^5.4 || ^6.4 || ^7.0",
+                "symfony/yaml": "^5.4 || ^6.4 || ^7.0"
+            },
+            "require-dev": {
+                "armin/editorconfig-cli": "^1.8 || ^2.0",
+                "composer/composer": "^2.2",
+                "eliashaeussler/php-cs-fixer-config": "^2.0",
+                "eliashaeussler/phpstan-config": "^2.0",
+                "eliashaeussler/rector-config": "^3.0",
+                "ergebnis/composer-normalize": "^2.30",
+                "phpstan/extension-installer": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.1",
+                "phpstan/phpstan-symfony": "^1.4",
+                "phpunit/phpunit": "^10.2 || ^11.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "EliasHaeussler\\VersionBumper\\VersionBumperPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "EliasHaeussler\\VersionBumper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Elias Häußler",
+                    "email": "elias@haeussler.dev",
+                    "homepage": "https://haeussler.dev",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Composer plugin to bump project versions during release preparations",
+            "support": {
+                "issues": "https://github.com/eliashaeussler/version-bumper/issues",
+                "source": "https://github.com/eliashaeussler/version-bumper/tree/1.0.0"
+            },
+            "time": "2024-09-23T15:29:10+00:00"
         },
         {
             "name": "ergebnis/composer-normalize",
@@ -6361,8 +6423,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "ext-zlib": "*",
-        "composer-runtime-api": "^2.1"
+        "ext-zlib": "*"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"

--- a/src/CacheWarmer.php
+++ b/src/CacheWarmer.php
@@ -42,6 +42,8 @@ use function is_string;
  */
 final class CacheWarmer
 {
+    public const VERSION = '3.1.3';
+
     private readonly Xml\XmlParser $parser;
 
     /**

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -623,12 +623,10 @@ HELP);
 
     private function printHeader(): void
     {
-        $currentVersion = Helper\VersionHelper::getCurrentVersion();
-
         $this->io->writeln(
             sprintf(
-                'Running <info>cache warmup</info>%s by Elias Häußler and contributors.',
-                null !== $currentVersion ? ' <comment>'.$currentVersion.'</comment>' : '',
+                'Running <info>cache warmup</info> <comment>%s</comment> by Elias Häußler and contributors.',
+                CacheWarmer::VERSION,
             ),
         );
     }

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -23,7 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
-use EliasHaeussler\CacheWarmup\Helper;
+use EliasHaeussler\CacheWarmup\CacheWarmer;
 use EliasHaeussler\CacheWarmup\Http;
 use Generator;
 use GuzzleHttp\ClientInterface;
@@ -113,8 +113,10 @@ trait ConcurrentCrawlerTrait
      */
     protected function getRequestHeaders(): array
     {
-        $currentVersion = Helper\VersionHelper::getCurrentVersion() ?? '1.0';
-        $userAgent = sprintf('EliasHaeussler-CacheWarmup/%s (https://github.com/eliashaeussler/cache-warmup)', $currentVersion);
+        $userAgent = sprintf(
+            'EliasHaeussler-CacheWarmup/%s (https://github.com/eliashaeussler/cache-warmup)',
+            CacheWarmer::VERSION,
+        );
 
         return [
             'User-Agent' => $userAgent,

--- a/src/Helper/VersionHelper.php
+++ b/src/Helper/VersionHelper.php
@@ -23,8 +23,7 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Helper;
 
-use Composer\InstalledVersions;
-use OutOfBoundsException;
+use EliasHaeussler\CacheWarmup\CacheWarmer;
 
 /**
  * VersionHelper.
@@ -36,12 +35,13 @@ use OutOfBoundsException;
  */
 final class VersionHelper
 {
-    public static function getCurrentVersion(): ?string
+    /**
+     * @deprecated since v3.1.4, use {@see CacheWarmer::VERSION} constant instead.
+     *
+     * @todo Remove with next major release
+     */
+    public static function getCurrentVersion(): string
     {
-        try {
-            return InstalledVersions::getPrettyVersion('eliashaeussler/cache-warmup');
-        } catch (OutOfBoundsException) {
-            return null;
-        }
+        return CacheWarmer::VERSION;
     }
 }

--- a/version-bumper.yaml
+++ b/version-bumper.yaml
@@ -1,0 +1,10 @@
+filesToModify:
+  - path: package.json
+    patterns:
+      - '"version": "{%version%}"'
+  - path: package-lock.json
+    patterns:
+      - '"name": "@eliashaeussler/cache-warmup",\s+"version": "{%version%}"'
+  - path: src/CacheWarmer.php
+    patterns:
+      - public const VERSION = '{%version%}'


### PR DESCRIPTION
This PR replaces the existing mechanism to retrieve the current library version. It was previously done using Composer's `InstalledVersions` class. Since this requires the Composer Runtime API, we now switch to a more convenient mechanism by providing it as a constant `CacheWarmer::VERSION`. In addition, the `eliashaeussler/version-bumper` plugin is included to make release preparations easier.

`VersionHelper::getCurrentVersion()` is now deprecated and will be removed with v4 of the library.