### PR TITLE
[FEATURE] Use limited service container to instantiate crawlers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
 		"psr/http-message": "^1.0 || ^2.0",
 		"psr/log": "^2.0 || ^3.0",
 		"symfony/console": "^5.4 || ^6.0 || ^7.0",
+		"symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",
 		"symfony/event-dispatcher": "^5.4 || ^6.0 || ^7.0",
 		"symfony/filesystem": "^5.4 || ^6.0 || ^7.0",
 		"symfony/options-resolver": "^5.4 || ^6.0 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b69901c9031149093b4abc320f87a09",
+    "content-hash": "06f5a42cc145818fbfe0c9ce3132cc21",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -1015,6 +1015,87 @@
             "time": "2024-09-20T08:15:52+00:00"
         },
         {
+            "name": "symfony/dependency-injection",
+            "version": "v6.4.12",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/dependency-injection.git",
+                "reference": "cfb9d34a1cdd4911bc737a5358fd1cf8ebfb536e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/cfb9d34a1cdd4911bc737a5358fd1cf8ebfb536e",
+                "reference": "cfb9d34a1cdd4911bc737a5358fd1cf8ebfb536e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/service-contracts": "^2.5|^3.0",
+                "symfony/var-exporter": "^6.2.10|^7.0"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2",
+                "symfony/config": "<6.1",
+                "symfony/finder": "<5.4",
+                "symfony/proxy-manager-bridge": "<6.3",
+                "symfony/yaml": "<5.4"
+            },
+            "provide": {
+                "psr/container-implementation": "1.1|2.0",
+                "symfony/service-implementation": "1.1|2.0|3.0"
+            },
+            "require-dev": {
+                "symfony/config": "^6.1|^7.0",
+                "symfony/expression-language": "^5.4|^6.0|^7.0",
+                "symfony/yaml": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\DependencyInjection\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows you to standardize and centralize the way objects are constructed in your application",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.12"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-20T08:18:25+00:00"
+        },
+        {
             "name": "symfony/deprecation-contracts",
             "version": "v3.5.0",
             "source": {
@@ -1856,6 +1937,83 @@
                 }
             ],
             "time": "2024-09-20T08:15:52+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v6.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "f9a060622e0d93777b7f8687ec4860191e16802e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/f9a060622e0d93777b7f8687ec4860191e16802e",
+                "reference": "f9a060622e0d93777b7f8687ec4860191e16802e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-06-24T15:53:56+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/docs/api/crawler.md
+++ b/docs/api/crawler.md
@@ -20,6 +20,20 @@ final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler
 }
 ```
 
+## Dependency Injection <Badge type="tip" text="3.2+" />
+
+When a crawler is created using
+[`EliasHaeussler\CacheWarmup\Crawler\CrawlerFactory`](../../src/Crawler/CrawlerFactory.php),
+a limited service container is built to instantiate the crawler.
+This allows custom crawlers to define dependencies to a limited
+set of services, including:
+
+* Current output (implementation of `OutputInterface`)
+* Current logger (implementation of `LoggerInterface`), only
+  available if the [`--log-file`](../config-reference/log-file.md)
+  command option is passed
+* Current event dispatcher (implementation of `EventDispatcherInterface`)
+
 ## Method Reference
 
 The default crawler describes the following method:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -16,12 +16,12 @@ parameters:
 			path: src/Config/Adapter/ConfigMapperFactory.php
 
 		-
-			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
+			message: "#^Parameter \\#1 \\$crawlerClass of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
 			count: 1
 			path: src/Config/Adapter/ConsoleInputConfigAdapter.php
 
 		-
-			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
+			message: "#^Parameter \\#1 \\$crawlerClass of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
 			count: 1
 			path: src/Config/Adapter/EnvironmentVariablesConfigAdapter.php
 
@@ -81,7 +81,7 @@ parameters:
 			path: tests/unit/Config/CacheWarmupConfigTest.php
 
 		-
-			message: "#^Parameter \\#1 \\$crawler of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
+			message: "#^Parameter \\#1 \\$crawlerClass of method EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\CrawlerFactory\\:\\:get\\(\\) expects class\\-string\\<EliasHaeussler\\\\CacheWarmup\\\\Crawler\\\\Crawler\\>, string given\\.$#"
 			count: 2
 			path: tests/unit/Crawler/CrawlerFactoryTest.php
 

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -387,7 +387,13 @@ HELP);
             }
         }
 
-        $this->crawlerFactory = new Crawler\CrawlerFactory($output, $logger, $logLevel, $stopOnFailure);
+        $this->crawlerFactory = new Crawler\CrawlerFactory(
+            $output,
+            $logger,
+            $logLevel,
+            $stopOnFailure,
+            $this->eventDispatcher,
+        );
     }
 
     protected function interact(Console\Input\InputInterface $input, Console\Output\OutputInterface $output): void

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -48,8 +48,6 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
 {
     use ConcurrentCrawlerTrait;
 
-    private ?Log\LoggerInterface $logger = null;
-
     /**
      * @phpstan-var Log\LogLevel::*
      */
@@ -59,6 +57,7 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
     public function __construct(
         array $options = [],
         private readonly ?ClientInterface $client = null,
+        private ?Log\LoggerInterface $logger = null,
     ) {
         parent::__construct($options);
     }

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -51,9 +51,6 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
 {
     use ConcurrentCrawlerTrait;
 
-    private Console\Output\OutputInterface $output;
-    private ?Log\LoggerInterface $logger = null;
-
     /**
      * @phpstan-var Log\LogLevel::*
      */
@@ -63,9 +60,10 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
     public function __construct(
         array $options = [],
         private readonly ?ClientInterface $client = null,
+        private Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
+        private ?Log\LoggerInterface $logger = null,
     ) {
         parent::__construct($options);
-        $this->output = new Console\Output\ConsoleOutput();
     }
 
     public function crawl(array $urls): Result\CacheWarmupResult

--- a/tests/unit/CacheWarmerTest.php
+++ b/tests/unit/CacheWarmerTest.php
@@ -74,7 +74,7 @@ final class CacheWarmerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function runPreparesUrlsWithConfiguredStrategy(): void
     {
-        $crawler = new Fixtures\Classes\DummyCrawler();
+        $crawler = new Fixtures\Classes\DummyCrawler($this->eventDispatcher);
         $subject = new Src\CacheWarmer(crawler: $crawler, strategy: new Src\Crawler\Strategy\SortByPriorityStrategy());
 
         $url1 = new Src\Sitemap\Url('https://www.example.org/foo', 0.75);
@@ -93,7 +93,7 @@ final class CacheWarmerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function runDispatchesUrlsPreparedEvent(): void
     {
-        $crawler = new Fixtures\Classes\DummyCrawler();
+        $crawler = new Fixtures\Classes\DummyCrawler($this->eventDispatcher);
         $subject = new Src\CacheWarmer(
             crawler: $crawler,
             strategy: new Src\Crawler\Strategy\SortByPriorityStrategy(),

--- a/tests/unit/Crawler/CrawlerFactoryTest.php
+++ b/tests/unit/Crawler/CrawlerFactoryTest.php
@@ -41,17 +41,20 @@ final class CrawlerFactoryTest extends Framework\TestCase
 {
     private Console\Output\BufferedOutput $output;
     private TransientLogger\TransientLogger $logger;
+    private Tests\Fixtures\Classes\DummyEventDispatcher $eventDispatcher;
     private Src\Crawler\CrawlerFactory $subject;
 
     protected function setUp(): void
     {
         $this->output = new Console\Output\BufferedOutput();
         $this->logger = new TransientLogger\TransientLogger();
+        $this->eventDispatcher = new Tests\Fixtures\Classes\DummyEventDispatcher();
         $this->subject = new Src\Crawler\CrawlerFactory(
             $this->output,
             $this->logger,
             Log\LogLevel::ERROR,
             true,
+            $this->eventDispatcher,
         );
     }
 
@@ -74,10 +77,10 @@ final class CrawlerFactoryTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function getReturnsCrawler(): void
     {
-        self::assertInstanceOf(
-            Tests\Fixtures\Classes\DummyCrawler::class,
-            $this->subject->get(Tests\Fixtures\Classes\DummyCrawler::class),
-        );
+        $actual = $this->subject->get(Tests\Fixtures\Classes\DummyCrawler::class);
+
+        self::assertInstanceOf(Tests\Fixtures\Classes\DummyCrawler::class, $actual);
+        self::assertSame($this->eventDispatcher, $actual->eventDispatcher);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/unit/Fixtures/Classes/DummyCrawler.php
+++ b/tests/unit/Fixtures/Classes/DummyCrawler.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes;
 
 use EliasHaeussler\CacheWarmup\Crawler;
 use EliasHaeussler\CacheWarmup\Result;
+use Psr\EventDispatcher;
 use Psr\Http\Message;
 
 use function array_shift;
@@ -48,6 +49,10 @@ class DummyCrawler implements Crawler\Crawler
      * @var list<Result\CrawlingState>
      */
     public static array $resultStack = [];
+
+    public function __construct(
+        public readonly EventDispatcher\EventDispatcherInterface $eventDispatcher,
+    ) {}
 
     public function crawl(array $urls): Result\CacheWarmupResult
     {


### PR DESCRIPTION
This PR changes the way how crawlers are instantiated via `CrawlerFactory`. The factory now builds a very limited service container with a small set of available services, including:

- the current output (aka an implementation of `OutputInterface`)
- the current logger (aka an implementation of `LoggerInterface`)
- the current event dispatcher (aka an implementation of `EventDispatcherInterface`)

Custom crawlers may define dependencies to these services and will get them injected automatically. Note that the logger service is only available if the `--log-file` command option is set.