### PR TITLE
[FEATURE] Provide events for URL crawling result collection

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -68,6 +68,28 @@ actions. This page lists all currently available events.
 
 > Dispatched right before crawling is started.
 
+### [`UrlCrawlingSucceeded`](../../src/Event/UrlCrawlingSucceeded.php) <Badge type="tip" text="3.2+" />
+
+<small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
+
+> Dispatched when crawling of a single URL was successful.
+
+::: warning IMPORTANT
+This event is only dispatched if the configured crawler utilizes the
+[`ResultCollectionHandler`](../../src/Http/Message/Handler/ResultCollectorHandler.php).
+:::
+
+### [`UrlCrawlingFailed`](../../src/Event/UrlCrawlingFailed.php) <Badge type="tip" text="3.2+" />
+
+<small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
+
+> Dispatched when crawling of a single URL failed.
+
+::: warning IMPORTANT
+This event is only dispatched if the configured crawler utilizes the
+[`ResultCollectionHandler`](../../src/Http/Message/Handler/ResultCollectorHandler.php).
+:::
+
 ### [`CrawlingFinished`](../../src/Event/CrawlingFinished.php) <Badge type="tip" text="3.2+" />
 
 <small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -28,6 +28,7 @@ use EliasHaeussler\CacheWarmup\Result;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise;
+use Psr\EventDispatcher;
 use Psr\Log;
 
 /**
@@ -58,13 +59,14 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
         array $options = [],
         private readonly ?ClientInterface $client = null,
         private ?Log\LoggerInterface $logger = null,
+        private readonly ?EventDispatcher\EventDispatcherInterface $eventDispatcher = null,
     ) {
         parent::__construct($options);
     }
 
     public function crawl(array $urls): Result\CacheWarmupResult
     {
-        $resultHandler = new Http\Message\Handler\ResultCollectorHandler();
+        $resultHandler = new Http\Message\Handler\ResultCollectorHandler($this->eventDispatcher);
         $result = $resultHandler->getResult();
         $handlers = [$resultHandler];
 

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -28,6 +28,7 @@ use EliasHaeussler\CacheWarmup\Result;
 use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Promise;
+use Psr\EventDispatcher;
 use Psr\Log;
 use Symfony\Component\Console;
 
@@ -62,6 +63,7 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
         private readonly ?ClientInterface $client = null,
         private Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
         private ?Log\LoggerInterface $logger = null,
+        private readonly ?EventDispatcher\EventDispatcherInterface $eventDispatcher = null,
     ) {
         parent::__construct($options);
     }
@@ -69,7 +71,7 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
     public function crawl(array $urls): Result\CacheWarmupResult
     {
         $numberOfUrls = count($urls);
-        $resultHandler = new Http\Message\Handler\ResultCollectorHandler();
+        $resultHandler = new Http\Message\Handler\ResultCollectorHandler($this->eventDispatcher);
         $result = $resultHandler->getResult();
 
         // Create progress response handler (depends on the available output)

--- a/src/Event/UrlCrawlingFailed.php
+++ b/src/Event/UrlCrawlingFailed.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Event;
+
+use EliasHaeussler\CacheWarmup\Result;
+use Psr\Http\Message;
+use Throwable;
+
+/**
+ * UrlCrawlingFailed.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class UrlCrawlingFailed
+{
+    public function __construct(
+        private readonly Message\UriInterface $uri,
+        private readonly Throwable $exception,
+        private Result\CrawlingResult $result,
+    ) {}
+
+    public function uri(): Message\UriInterface
+    {
+        return $this->uri;
+    }
+
+    public function exception(): Throwable
+    {
+        return $this->exception;
+    }
+
+    public function result(): Result\CrawlingResult
+    {
+        return $this->result;
+    }
+
+    public function setResult(Result\CrawlingResult $result): self
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+}

--- a/src/Event/UrlCrawlingSucceeded.php
+++ b/src/Event/UrlCrawlingSucceeded.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Event;
+
+use EliasHaeussler\CacheWarmup\Result;
+use Psr\Http\Message;
+
+/**
+ * UrlCrawlingSucceeded.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class UrlCrawlingSucceeded
+{
+    public function __construct(
+        private readonly Message\UriInterface $uri,
+        private readonly Message\ResponseInterface $response,
+        private Result\CrawlingResult $result,
+    ) {}
+
+    public function uri(): Message\UriInterface
+    {
+        return $this->uri;
+    }
+
+    public function response(): Message\ResponseInterface
+    {
+        return $this->response;
+    }
+
+    public function result(): Result\CrawlingResult
+    {
+        return $this->result;
+    }
+
+    public function setResult(Result\CrawlingResult $result): self
+    {
+        $this->result = $result;
+
+        return $this;
+    }
+}


### PR DESCRIPTION
This PR adds two new events:

* `UrlCrawlingSucceeded`
* `UrlCrawlingFinished`

Both events are dispatched in the `ResultCollectorHandler` in `onSuccess` and `onFailure` methods, respectively. They allow to enhance or exchange the generated `CrawlingResult` objects.