### PR TITLE
[BUGFIX] Mark `cuyz/valinor` v1.14.0 as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,6 +46,9 @@
 		"phpstan/phpstan-symfony": "^1.2.11",
 		"phpunit/phpunit": "^10.1 || ^11.0"
 	},
+	"conflict": {
+		"cuyz/valinor": "1.14.0"
+	},
 	"autoload": {
 		"psr-4": {
 			"EliasHaeussler\\CacheWarmup\\": "src"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "06f5a42cc145818fbfe0c9ce3132cc21",
+    "content-hash": "10d91a876d88904b54b6dd167b143055",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -6630,7 +6630,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
@@ -6640,6 +6640,6 @@
         "ext-mbstring": "*",
         "ext-zlib": "*"
     },
-    "platform-dev": {},
+    "platform-dev": [],
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
`cuyz/valinor` introduced a reflection-related change with v1.14.0 which is not compatible to how this library uses class imports. Thus, the version is marked as conflicting as long as the fix is not resolved.

Related:

* CuyZ/Valinor#574
* #409
* #408