### PR TITLE
[!!!][FEATURE] Don't write crawling response body by default

### DIFF
--- a/docs/config-reference/crawler-options.md
+++ b/docs/config-reference/crawler-options.md
@@ -324,3 +324,49 @@ CACHE_WARMUP_CRAWLER_OPTIONS='{"request_options": {"delay": 500, "timeout": 10}}
 ```
 
 :::
+
+### `write_response_body` <Badge type="tip" text="4.0+" />
+
+<small>🎨&nbsp;Type: `bool` &middot; 🐝&nbsp;Default: `false`</small>
+
+> Define whether or not to write response body of crawled URLs to the corresponding
+> response object.
+
+::: warning
+Enabling this option may significantly increase memory consumption during cache warmup.
+:::
+
+::: code-group
+
+```bash [CLI]
+./cache-warmup.phar --crawler-options '{"write_response_body": true}'
+```
+
+```json [JSON]
+{
+    "crawlerOptions": {
+        "write_response_body": true
+    }
+}
+```
+
+```php [PHP]
+use EliasHaeussler\CacheWarmup;
+
+return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
+    $config->setCrawlerOption('write_response_body', true);
+
+    return $config;
+};
+```
+
+```yaml [YAML]
+crawlerOptions:
+  write_response_body: true
+```
+
+```bash [.env]
+CACHE_WARMUP_CRAWLER_OPTIONS='{"write_response_body": true}'
+```
+
+:::

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -43,6 +43,7 @@ use Psr\Log;
  *     request_headers: array<string, string>,
  *     request_options: array<string, mixed>,
  *     client_config: array<string, mixed>,
+ *     write_response_body: bool,
  * }>
  */
 final class ConcurrentCrawler extends AbstractConfigurableCrawler implements LoggingCrawler, StoppableCrawler

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -46,6 +46,7 @@ use function count;
  *     request_headers: array<string, string>,
  *     request_options: array<string, mixed>,
  *     client_config: array<string, mixed>,
+ *     write_response_body: bool,
  * }>
  */
 final class OutputtingCrawler extends AbstractConfigurableCrawler implements LoggingCrawler, StoppableCrawler, VerboseCrawler

--- a/src/Http/Message/Stream/NullStream.php
+++ b/src/Http/Message/Stream/NullStream.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Http\Message\Stream;
+
+use function in_array;
+use function stream_get_wrappers;
+use function stream_wrapper_register;
+use function stream_wrapper_unregister;
+
+/**
+ * NullStream.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final class NullStream
+{
+    private const PROTOCOL = 'null';
+
+    /**
+     * @var resource|null
+     */
+    public $context;
+
+    public static function register(): void
+    {
+        if (!self::isRegistered()) {
+            stream_wrapper_register(self::PROTOCOL, self::class);
+        }
+    }
+
+    public static function unregister(): void
+    {
+        if (self::isRegistered()) {
+            stream_wrapper_unregister(self::PROTOCOL);
+        }
+    }
+
+    private static function isRegistered(): bool
+    {
+        return in_array(self::PROTOCOL, stream_get_wrappers(), true);
+    }
+
+    public function stream_close(): void {}
+
+    public function stream_eof(): bool
+    {
+        return true;
+    }
+
+    public function stream_flush(): bool
+    {
+        return true;
+    }
+
+    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
+    {
+        return true;
+    }
+
+    public function stream_read(int $count): string
+    {
+        return '';
+    }
+
+    public function stream_seek(int $count, int $whence = SEEK_SET): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array{}
+     */
+    public function stream_stat(): array
+    {
+        return [];
+    }
+
+    public function stream_tell(): int
+    {
+        return 0;
+    }
+
+    public function stream_write(string $data): int
+    {
+        // 1 is enough for curl handler to not fail during writing
+        return '' === $data ? 0 : 1;
+    }
+}

--- a/tests/unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/unit/Crawler/OutputtingCrawlerTest.php
@@ -28,10 +28,13 @@ use EliasHaeussler\CacheWarmup\Tests;
 use EliasHaeussler\TransientLogger;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
+use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework;
 use Psr\Http\Message;
 use Psr\Log;
 use Symfony\Component\Console;
+
+use function stream_get_meta_data;
 
 /**
  * OutputtingCrawlerTest.
@@ -98,6 +101,45 @@ final class OutputtingCrawlerTest extends Framework\TestCase
         $subject->crawl([new Psr7\Uri('https://www.example.org')]);
 
         self::assertNull($this->mockHandler->getLastRequest());
+    }
+
+    #[Framework\Attributes\Test]
+    public function crawlDoesNotWritesResponseBodyByDefault(): void
+    {
+        $this->mockHandler->append(new Psr7\Response());
+
+        $this->subject->crawl([new Psr7\Uri('https://www.example.org')]);
+
+        $lastOptions = $this->mockHandler->getLastOptions();
+        $sink = $lastOptions[RequestOptions::SINK] ?? null;
+
+        self::assertIsResource($sink);
+        self::assertInstanceOf(
+            Src\Http\Message\Stream\NullStream::class,
+            stream_get_meta_data($sink)['wrapper_data'],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function crawlWritesResponseBodyIfConfigured(): void
+    {
+        $this->mockHandler->append(new Psr7\Response());
+
+        $subject = new Src\Crawler\ConcurrentCrawler(
+            [
+                'client_config' => [
+                    'handler' => $this->mockHandler,
+                ],
+                'write_response_body' => true,
+            ],
+        );
+
+        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
+
+        $lastOptions = $this->mockHandler->getLastOptions();
+        $sink = $lastOptions[RequestOptions::SINK] ?? null;
+
+        self::assertNull($sink);
     }
 
     #[Framework\Attributes\Test]

--- a/tests/unit/Http/Message/Stream/NullStreamTest.php
+++ b/tests/unit/Http/Message/Stream/NullStreamTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Http\Message\Stream;
+
+use EliasHaeussler\CacheWarmup as Src;
+use PHPUnit\Framework;
+
+use function array_values;
+use function fclose;
+use function feof;
+use function fflush;
+use function fopen;
+use function fread;
+use function fseek;
+use function fstat;
+use function ftell;
+use function fwrite;
+use function is_resource;
+
+/**
+ * NullStreamTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Http\Message\Stream\NullStream::class)]
+final class NullStreamTest extends Framework\TestCase
+{
+    /**
+     * @var resource
+     */
+    private $subject;
+
+    public function setUp(): void
+    {
+        Src\Http\Message\Stream\NullStream::register();
+
+        $resource = fopen('null:///', 'w+');
+
+        if (!is_resource($resource)) {
+            self::fail('Cannot create resource.');
+        }
+
+        $this->subject = $resource;
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamEofReturnsTrue(): void
+    {
+        self::assertTrue(feof($this->subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamFlushReturnsTrue(): void
+    {
+        self::assertTrue(fflush($this->subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamOpenOpensStream(): void
+    {
+        $actual = fopen('null:///foo', 'r');
+
+        self::assertIsResource($actual);
+
+        fclose($actual);
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamReadReturnsEmptyString(): void
+    {
+        self::assertSame('', fread($this->subject, 124));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamSeekReturnsZero(): void
+    {
+        self::assertSame(0, fseek($this->subject, 0));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamStatReturnsArrayWithEmptyInformation(): void
+    {
+        $blockSize = PHP_OS_FAMILY === 'Windows' ? -1 : 0;
+        $statistics = [
+            'dev' => 0,
+            'ino' => 0,
+            'mode' => 0,
+            'nlink' => 0,
+            'uid' => 0,
+            'gid' => 0,
+            'rdev' => 0,
+            'size' => 0,
+            'atime' => 0,
+            'mtime' => 0,
+            'ctime' => 0,
+            'blksize' => $blockSize,
+            'blocks' => $blockSize,
+        ];
+
+        $expected = [
+            ...array_values($statistics),
+            ...$statistics,
+        ];
+
+        self::assertSame($expected, fstat($this->subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamTellReturnsZero(): void
+    {
+        self::assertSame(0, ftell($this->subject));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamWriteReturnsZeroOnEmptyData(): void
+    {
+        self::assertSame(0, fwrite($this->subject, ''));
+    }
+
+    #[Framework\Attributes\Test]
+    public function streamWriteReturnsNonZeroOnNonEmptyData(): void
+    {
+        self::assertSame(3, fwrite($this->subject, 'foo'));
+    }
+
+    protected function tearDown(): void
+    {
+        fclose($this->subject);
+
+        Src\Http\Message\Stream\NullStream::unregister();
+    }
+}


### PR DESCRIPTION
This PR adds a new crawler option `write_response_body` which defaults to `false`. When disabled, crawling responses won't get the response body attached. Instead, response body is written to a `NullStream` which discards all received data.

Since this changes existing behavior, it is considered breaking. Consumers relying on the availability of the actual response body can restore original behavior by setting the crawler option to `true`.