### PR TITLE
[!!!][TASK] Switch to PSR-7 stream implementation for `NullStream`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
 		"guzzlehttp/promises": "^1.0 || ^2.0",
 		"guzzlehttp/psr7": "^2.0",
 		"psr/event-dispatcher": "^1.0",
-		"psr/http-message": "^1.0 || ^2.0",
+		"psr/http-message": "^2.0",
 		"psr/log": "^2.0 || ^3.0",
 		"symfony/console": "^5.4 || ^6.0 || ^7.0",
 		"symfony/dependency-injection": "^5.4 || ^6.0 || ^7.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "39f217dbaf2b4e8cb466c33e8bcd1456",
+    "content-hash": "68add503d4e7cc9bc13e730d188f5f2f",
     "packages": [
         {
             "name": "cuyz/valinor",

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -31,7 +31,6 @@ use Psr\Http\Message;
 use Symfony\Component\OptionsResolver;
 
 use function array_key_exists;
-use function fopen;
 
 /**
  * ConcurrentCrawlerTrait.
@@ -93,10 +92,7 @@ trait ConcurrentCrawlerTrait
         $options = $this->options['request_options'];
 
         if (!$this->options['write_response_body'] && !array_key_exists(RequestOptions::SINK, $options)) {
-            Http\Message\Stream\NullStream::register();
-            $options[RequestOptions::SINK] = fopen('null:///', 'w+');
-        } else {
-            Http\Message\Stream\NullStream::unregister();
+            $options[RequestOptions::SINK] = new Http\Message\Stream\NullStream();
         }
 
         return Http\Message\RequestPoolFactory::create($requestFactory->buildIterable($urls))

--- a/src/Http/Message/Stream/NullStream.php
+++ b/src/Http/Message/Stream/NullStream.php
@@ -23,10 +23,9 @@ declare(strict_types=1);
 
 namespace EliasHaeussler\CacheWarmup\Http\Message\Stream;
 
-use function in_array;
-use function stream_get_wrappers;
-use function stream_wrapper_register;
-use function stream_wrapper_unregister;
+use Psr\Http\Message;
+
+use function strlen;
 
 /**
  * NullStream.
@@ -34,77 +33,74 @@ use function stream_wrapper_unregister;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class NullStream
+final class NullStream implements Message\StreamInterface
 {
-    private const PROTOCOL = 'null';
-
-    /**
-     * @var resource|null
-     */
-    public $context;
-
-    public static function register(): void
-    {
-        if (!self::isRegistered()) {
-            stream_wrapper_register(self::PROTOCOL, self::class);
-        }
-    }
-
-    public static function unregister(): void
-    {
-        if (self::isRegistered()) {
-            stream_wrapper_unregister(self::PROTOCOL);
-        }
-    }
-
-    private static function isRegistered(): bool
-    {
-        return in_array(self::PROTOCOL, stream_get_wrappers(), true);
-    }
-
-    public function stream_close(): void {}
-
-    public function stream_eof(): bool
-    {
-        return true;
-    }
-
-    public function stream_flush(): bool
-    {
-        return true;
-    }
-
-    public function stream_open(string $path, string $mode, int $options, ?string &$opened_path): bool
-    {
-        return true;
-    }
-
-    public function stream_read(int $count): string
+    public function __toString(): string
     {
         return '';
     }
 
-    public function stream_seek(int $count, int $whence = SEEK_SET): bool
+    public function close(): void {}
+
+    public function detach()
     {
-        return true;
+        return null;
     }
 
-    /**
-     * @return array{}
-     */
-    public function stream_stat(): array
-    {
-        return [];
-    }
-
-    public function stream_tell(): int
+    public function getSize(): int
     {
         return 0;
     }
 
-    public function stream_write(string $data): int
+    public function tell(): int
     {
-        // 1 is enough for curl handler to not fail during writing
-        return '' === $data ? 0 : 1;
+        return 0;
+    }
+
+    public function eof(): bool
+    {
+        return true;
+    }
+
+    public function isSeekable(): bool
+    {
+        return true;
+    }
+
+    public function seek(int $offset, int $whence = SEEK_SET): void {}
+
+    public function rewind(): void {}
+
+    public function isWritable(): bool
+    {
+        return true;
+    }
+
+    public function write(string $string): int
+    {
+        return strlen($string);
+    }
+
+    public function isReadable(): bool
+    {
+        return true;
+    }
+
+    public function read(int $length): string
+    {
+        return '';
+    }
+
+    public function getContents(): string
+    {
+        return '';
+    }
+
+    /**
+     * @return array{}|null
+     */
+    public function getMetadata(?string $key = null): ?array
+    {
+        return null !== $key ? null : [];
     }
 }

--- a/tests/unit/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/unit/Crawler/ConcurrentCrawlerTest.php
@@ -33,8 +33,6 @@ use PHPUnit\Framework;
 use Psr\Http\Message;
 use Psr\Log;
 
-use function stream_get_meta_data;
-
 /**
  * ConcurrentCrawlerTest.
  *
@@ -105,12 +103,10 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
         $this->subject->crawl([new Psr7\Uri('https://www.example.org')]);
 
         $lastOptions = $this->mockHandler->getLastOptions();
-        $sink = $lastOptions[RequestOptions::SINK] ?? null;
 
-        self::assertIsResource($sink);
         self::assertInstanceOf(
             Src\Http\Message\Stream\NullStream::class,
-            stream_get_meta_data($sink)['wrapper_data'],
+            $lastOptions[RequestOptions::SINK] ?? null,
         );
     }
 

--- a/tests/unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/unit/Crawler/OutputtingCrawlerTest.php
@@ -34,8 +34,6 @@ use Psr\Http\Message;
 use Psr\Log;
 use Symfony\Component\Console;
 
-use function stream_get_meta_data;
-
 /**
  * OutputtingCrawlerTest.
  *
@@ -113,10 +111,9 @@ final class OutputtingCrawlerTest extends Framework\TestCase
         $lastOptions = $this->mockHandler->getLastOptions();
         $sink = $lastOptions[RequestOptions::SINK] ?? null;
 
-        self::assertIsResource($sink);
         self::assertInstanceOf(
             Src\Http\Message\Stream\NullStream::class,
-            stream_get_meta_data($sink)['wrapper_data'],
+            $lastOptions[RequestOptions::SINK] ?? null,
         );
     }
 

--- a/tests/unit/Http/Message/Stream/NullStreamTest.php
+++ b/tests/unit/Http/Message/Stream/NullStreamTest.php
@@ -26,18 +26,6 @@ namespace EliasHaeussler\CacheWarmup\Tests\Http\Message\Stream;
 use EliasHaeussler\CacheWarmup as Src;
 use PHPUnit\Framework;
 
-use function array_values;
-use function fclose;
-use function feof;
-use function fflush;
-use function fopen;
-use function fread;
-use function fseek;
-use function fstat;
-use function ftell;
-use function fwrite;
-use function is_resource;
-
 /**
  * NullStreamTest.
  *
@@ -47,108 +35,82 @@ use function is_resource;
 #[Framework\Attributes\CoversClass(Src\Http\Message\Stream\NullStream::class)]
 final class NullStreamTest extends Framework\TestCase
 {
-    /**
-     * @var resource
-     */
-    private $subject;
+    private Src\Http\Message\Stream\NullStream $subject;
 
     public function setUp(): void
     {
-        Src\Http\Message\Stream\NullStream::register();
-
-        $resource = fopen('null:///', 'w+');
-
-        if (!is_resource($resource)) {
-            self::fail('Cannot create resource.');
-        }
-
-        $this->subject = $resource;
+        $this->subject = new Src\Http\Message\Stream\NullStream();
     }
 
     #[Framework\Attributes\Test]
-    public function streamEofReturnsTrue(): void
+    public function toStringReturnsEmptyString(): void
     {
-        self::assertTrue(feof($this->subject));
+        self::assertSame('', (string) $this->subject);
     }
 
     #[Framework\Attributes\Test]
-    public function streamFlushReturnsTrue(): void
+    public function detachReturnsNull(): void
     {
-        self::assertTrue(fflush($this->subject));
+        self::assertNull($this->subject->detach());
     }
 
     #[Framework\Attributes\Test]
-    public function streamOpenOpensStream(): void
+    public function getSizeReturnsZero(): void
     {
-        $actual = fopen('null:///foo', 'r');
-
-        self::assertIsResource($actual);
-
-        fclose($actual);
+        self::assertSame(0, $this->subject->getSize());
     }
 
     #[Framework\Attributes\Test]
-    public function streamReadReturnsEmptyString(): void
+    public function eofReturnsTrue(): void
     {
-        self::assertSame('', fread($this->subject, 124));
+        self::assertTrue($this->subject->eof());
     }
 
     #[Framework\Attributes\Test]
-    public function streamSeekReturnsZero(): void
+    public function isSeekableReturnsTrue(): void
     {
-        self::assertSame(0, fseek($this->subject, 0));
+        self::assertTrue($this->subject->isSeekable());
     }
 
     #[Framework\Attributes\Test]
-    public function streamStatReturnsArrayWithEmptyInformation(): void
+    public function isWritableReturnsTrue(): void
     {
-        $blockSize = PHP_OS_FAMILY === 'Windows' ? -1 : 0;
-        $statistics = [
-            'dev' => 0,
-            'ino' => 0,
-            'mode' => 0,
-            'nlink' => 0,
-            'uid' => 0,
-            'gid' => 0,
-            'rdev' => 0,
-            'size' => 0,
-            'atime' => 0,
-            'mtime' => 0,
-            'ctime' => 0,
-            'blksize' => $blockSize,
-            'blocks' => $blockSize,
-        ];
-
-        $expected = [
-            ...array_values($statistics),
-            ...$statistics,
-        ];
-
-        self::assertSame($expected, fstat($this->subject));
+        self::assertTrue($this->subject->isWritable());
     }
 
     #[Framework\Attributes\Test]
-    public function streamTellReturnsZero(): void
+    public function writeReturnsStringLength(): void
     {
-        self::assertSame(0, ftell($this->subject));
+        self::assertSame(3, $this->subject->write('foo'));
     }
 
     #[Framework\Attributes\Test]
-    public function streamWriteReturnsZeroOnEmptyData(): void
+    public function isReadableReturnsTrue(): void
     {
-        self::assertSame(0, fwrite($this->subject, ''));
+        self::assertTrue($this->subject->isReadable());
     }
 
     #[Framework\Attributes\Test]
-    public function streamWriteReturnsNonZeroOnNonEmptyData(): void
+    public function readReturnsEmptyString(): void
     {
-        self::assertSame(3, fwrite($this->subject, 'foo'));
+        self::assertSame('', $this->subject->read(128));
     }
 
-    protected function tearDown(): void
+    #[Framework\Attributes\Test]
+    public function getContentsReturnsEmptyString(): void
     {
-        fclose($this->subject);
+        self::assertSame('', $this->subject->getContents());
+    }
 
-        Src\Http\Message\Stream\NullStream::unregister();
+    #[Framework\Attributes\Test]
+    public function getMetadataReturnsNullIfKeyIsGiven(): void
+    {
+        self::assertNull($this->subject->getMetadata('foo'));
+    }
+
+    #[Framework\Attributes\Test]
+    public function getMetadataReturnsEmptyArrayIfNoKeyIsGiven(): void
+    {
+        self::assertSame([], $this->subject->getMetadata());
     }
 }


### PR DESCRIPTION
This PR switches the recently introduced `NullStream` to a PSR-7 compatible stream. This improves CPU load when response objects are built, because a stream is no longer wrapped around the previously implemented stream wrapper.

This change is considered breaking because support for `psr/http-message` 1.x is dropped.