### PR TITLE
[TASK] Reduce excessive progress bar step rendering

### DIFF
--- a/tests/unit/Http/Message/Handler/VerboseProgressHandlerTest.php
+++ b/tests/unit/Http/Message/Handler/VerboseProgressHandlerTest.php
@@ -77,6 +77,10 @@ final class VerboseProgressHandlerTest extends Framework\TestCase
         $uri = new Psr7\Uri('https://www.example.com');
 
         $this->subject->startProgressBar();
+
+        // Ensure progress bar is rendered on next step (redraw frequency is 1 second)
+        sleep(1);
+
         $this->subject->onSuccess($response, $uri);
 
         $output = $this->output->fetch();


### PR DESCRIPTION
Prior to this PR, the progress bar used in `VerboseProgressHandler` was rendered on each step. This leads to a performance overload which can be safely avoided by reducing the number of redraws, which is done by this PR.