### PR TITLE
[!!!][FEATURE] Introduce `ClientFactory` and `clientOptions` config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,6 +10,7 @@
 /CODEOWNERS               export-ignore
 /composer.lock            export-ignore
 /CONTRIBUTING.md          export-ignore
+/dependency-checker.json  export-ignore
 /package.json             export-ignore
 /package-lock.json        export-ignore
 /phpstan.php              export-ignore

--- a/.github/workflows/cgl.yaml
+++ b/.github/workflows/cgl.yaml
@@ -48,7 +48,7 @@ jobs:
 
       # Check dependencies
       - name: Check Composer dependencies
-        run: composer-require-checker check
+        run: composer-require-checker check --config-file dependency-checker.json
       - name: Check for unused Composer dependencies
         run: composer-unused --excludePackage=ext-zlib
       - name: Check for unused Frontend dependencies

--- a/composer.json
+++ b/composer.json
@@ -46,8 +46,9 @@
 		"phpstan/phpstan-phpunit": "^2.0",
 		"phpstan/phpstan-symfony": "^2.0",
 		"phpunit/phpunit": "^11.5.1",
+		"symfony/config": "^5.4.35 || ^6.4.3 || ^7.0.3",
 		"symfony/event-dispatcher-contracts": "^2.5.3 || ^3.4.2",
-		"symfony/string": "^6.4.3 || ^7.0.3"
+		"symfony/string": "^5.4.35 || ^6.4.3 || ^7.0.3"
 	},
 	"conflict": {
 		"cuyz/valinor": "1.14.0"
@@ -97,7 +98,10 @@
 		"sca": [
 			"@sca:php"
 		],
-		"sca:php": "phpstan analyse -c phpstan.php",
+		"sca:php": [
+			"@php tests/build/service-container.php",
+			"phpstan analyse -c phpstan.php"
+		],
 		"test": [
 			"@test:e2e",
 			"@test:unit"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b5b1aaf090b3a808522ce35d50bda943",
+    "content-hash": "3012368daf56f00e1954ba5fbde0f74e",
     "packages": [
         {
             "name": "cuyz/valinor",
@@ -6326,6 +6326,81 @@
                 }
             ],
             "time": "2024-10-20T05:08:20+00:00"
+        },
+        {
+            "name": "symfony/config",
+            "version": "v7.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/config.git",
+                "reference": "bcd3c4adf0144dee5011bb35454728c38adec055"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/config/zipball/bcd3c4adf0144dee5011bb35454728c38adec055",
+                "reference": "bcd3c4adf0144dee5011bb35454728c38adec055",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/filesystem": "^7.1",
+                "symfony/polyfill-ctype": "~1.8"
+            },
+            "conflict": {
+                "symfony/finder": "<6.4",
+                "symfony/service-contracts": "<2.5"
+            },
+            "require-dev": {
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/service-contracts": "^2.5|^3",
+                "symfony/yaml": "^6.4|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Config\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/config/tree/v7.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-11-04T11:36:24+00:00"
         },
         {
             "name": "symfony/finder",

--- a/dependency-checker.json
+++ b/dependency-checker.json
@@ -1,0 +1,5 @@
+{
+	"symbol-whitelist": [
+		"Symfony\\Component\\Config\\ConfigCache"
+	]
+}

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -104,6 +104,13 @@ export default defineConfig({
                         ],
                     },
                     {
+                        text: 'Client',
+                        collapsed: true,
+                        items: [
+                            {text: 'Client options', link: '/config-reference/client-options'},
+                        ],
+                    },
+                    {
                         text: 'Crawling',
                         collapsed: true,
                         items: [
@@ -162,6 +169,10 @@ export default defineConfig({
                             {text: 'Create a custom parser', link: '/api/parser'},
                             {text: 'Configurable Parser', link: '/api/configurable-parser'},
                         ],
+                    },
+                    {
+                        text: 'Dependency injection',
+                        link: '/api/dependency-injection',
                     },
                     {
                         text: 'Events',

--- a/docs/api/crawler.md
+++ b/docs/api/crawler.md
@@ -20,20 +20,6 @@ final class MyCustomCrawler implements CacheWarmup\Crawler\Crawler
 }
 ```
 
-## Dependency Injection <Badge type="tip" text="3.2+" />
-
-When a crawler is created using
-[`EliasHaeussler\CacheWarmup\Crawler\CrawlerFactory`](../../src/Crawler/CrawlerFactory.php),
-a limited service container is built to instantiate the crawler.
-This allows custom crawlers to define dependencies to a limited
-set of services, including:
-
-* Current output (implementation of `OutputInterface`)
-* Current logger (implementation of `LoggerInterface`), only
-  available if the [`--log-file`](../config-reference/log-file.md)
-  command option is passed
-* Current event dispatcher (implementation of `EventDispatcherInterface`)
-
 ## Method Reference
 
 The default crawler describes the following method:

--- a/docs/api/dependency-injection.md
+++ b/docs/api/dependency-injection.md
@@ -1,0 +1,25 @@
+# Dependency injection <Badge type="tip" text="3.2+" />
+
+A limited service container is built to instantiate crawlers and
+parsers. This allows custom crawlers to define dependencies to a
+limited set of services.
+
+## Included services
+
+The container includes the following runtime services:
+
+| Service                                                                                                               | Description                                                                                                                      | Added&nbsp;in                     |
+|-----------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------|-----------------------------------|
+| [`OutputInterface`](https://github.com/symfony/console/blob/v5.4.35/Output/OutputInterface.php)                       | Current output, either extracted from console application or constructed as `ConsoleOutput`                                      | <Badge type="tip" text="3.2.0" /> |
+| [`LoggerInterface`](https://github.com/php-fig/log/blob/2.0.0/src/LoggerInterface.php)                                | Current logger, only available if the [`logFile`](../config-reference/log-file.md) configuration option is passed                | <Badge type="tip" text="3.2.0" /> |
+| [`EventDispatcherInterface`](https://github.com/php-fig/event-dispatcher/blob/1.0.0/src/EventDispatcherInterface.php) | Current event dispatcher instance, either extracted from console application or constructed as new instance                      | <Badge type="tip" text="3.2.0" /> |
+| [`ClientFactory`](../../src/Http/Client/ClientFactory.php)                                                            | Factory to create Guzzle client with defaults from [`clientOptions`](../config-reference/client-options.md) configuration option | <Badge type="tip" text="4.0.0" /> |
+| [`ClientInterface`](https://github.com/guzzle/guzzle/blob/7.8.2/src/ClientInterface.php)                              | Shared Guzzle client, constructed with [`clientOptions`](../config-reference/client-options.md) configuration option             | <Badge type="tip" text="4.0.0" /> |
+
+## Supported factories
+
+The service container is built when creating crawlers and parsers
+through their respective factories, including:
+
+* [`EliasHaeussler\CacheWarmup\Crawler\CrawlerFactory`](../../src/Crawler/CrawlerFactory.php)
+* [`EliasHaeussler\CacheWarmup\Xml\ParserFactory`](../../src/Xml/ParserFactory.php)

--- a/docs/config-reference/client-options.md
+++ b/docs/config-reference/client-options.md
@@ -1,0 +1,60 @@
+---
+outline: [2,3]
+---
+
+# Client options <Badge type="tip" text="4.0+" />
+
+<small>📝&nbsp;Name: `clientOptions` &middot; 🖥️&nbsp;Option:  `-t`, `--client-options`</small>
+
+> Additional [configuration](https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client)
+> for shared Guzzle client.
+
+::: info
+The shared Guzzle client is used in default crawlers and default parser. Custom
+crawlers and parsers may also use it, if properly configured via
+[dependency injection](../api/dependency-injection.md).
+:::
+
+## Example
+
+Pass client options in the expected input format.
+
+::: warning IMPORTANT
+When passing client options as **command parameter** or **environment variable**,
+make sure to pass them as **JSON-encoded string**.
+:::
+
+::: code-group
+
+```bash [CLI]
+./cache-warmup.phar --client-options '{"auth": ["username", "password"]}'
+```
+
+```json [JSON]
+{
+    "clientOptions": {
+        "auth": ["username", "password"]
+    }
+}
+```
+
+```php [PHP]
+use EliasHaeussler\CacheWarmup;
+
+return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
+    $config->setClientOption('auth', ['username', 'password']);
+
+    return $config;
+};
+```
+
+```yaml [YAML]
+clientOptions:
+  auth: ['username', 'password']
+```
+
+```bash [.env]
+CACHE_WARMUP_CLIENT_OPTIONS='{"auth": ["username", "password"]}'
+```
+
+:::

--- a/docs/config-reference/index.md
+++ b/docs/config-reference/index.md
@@ -44,6 +44,12 @@ Defines how to format cache warmup progress and result.
 * [Progress](progress.md)
 * [Endless mode](repeat-after.md)
 
+## Client
+
+Describes options to customize the shared Guzzle client.
+
+* [Client options](client-options.md)
+
 ## Crawling
 
 Describes options to modify and customize the crawling behavior.

--- a/phpstan.php
+++ b/phpstan.php
@@ -25,6 +25,7 @@ use EliasHaeussler\PHPStanConfig;
 
 $symfonySet = PHPStanConfig\Set\SymfonySet::create()
     ->withConsoleApplicationLoader('tests/build/console-application.php')
+    ->withContainerXmlPath('.build/container.xml')
 ;
 
 return PHPStanConfig\Config\Config::create(__DIR__)

--- a/src/Config/Adapter/EnvironmentVariablesConfigAdapter.php
+++ b/src/Config/Adapter/EnvironmentVariablesConfigAdapter.php
@@ -52,15 +52,11 @@ final readonly class EnvironmentVariablesConfigAdapter implements ConfigAdapter
         '1',
     ];
 
-    private Crawler\CrawlerFactory $crawlerFactory;
-    private Xml\ParserFactory $parserFactory;
     private Config\Component\OptionsParser $optionsParser;
     private Valinor\Mapper\TreeMapper $mapper;
 
     public function __construct()
     {
-        $this->crawlerFactory = new Crawler\CrawlerFactory();
-        $this->parserFactory = new Xml\ParserFactory();
         $this->optionsParser = new Config\Component\OptionsParser();
         $this->mapper = (new ConfigMapperFactory())->get();
     }
@@ -124,17 +120,17 @@ final readonly class EnvironmentVariablesConfigAdapter implements ConfigAdapter
     {
         // Test if given crawler is supported (throws exception if it's invalid)
         if ('crawler' === $name && '' !== trim($envVarValue)) {
-            $this->crawlerFactory->validate($envVarValue);
+            Crawler\CrawlerFactory::validate($envVarValue);
         }
 
         // Test if given parser is supported (throws exception if it's invalid)
         if ('parser' === $name && '' !== trim($envVarValue)) {
-            $this->parserFactory->validate($envVarValue);
+            Xml\ParserFactory::validate($envVarValue);
         }
 
         return match (gettype($defaultValue)) {
             'array' => match ($name) {
-                'crawlerOptions', 'parserOptions' => $this->optionsParser->parse($envVarValue),
+                'clientOptions', 'crawlerOptions', 'parserOptions' => $this->optionsParser->parse($envVarValue),
                 default => Helper\ArrayHelper::trimExplode($envVarValue),
             },
             'boolean' => in_array(trim($envVarValue), self::BOOLEAN_VALUES, true),

--- a/src/Config/CacheWarmupConfig.php
+++ b/src/Config/CacheWarmupConfig.php
@@ -50,6 +50,7 @@ final class CacheWarmupConfig
      * @param list<Sitemap\Url>                                  $urls
      * @param list<Option\ExcludePattern>                        $excludePatterns
      * @param int<0, max>                                        $limit
+     * @param array<string, mixed>                               $clientOptions
      * @param Crawler\Crawler|class-string<Crawler\Crawler>|null $crawler
      * @param array<string, mixed>                               $crawlerOptions
      * @param Xml\Parser|class-string<Xml\Parser>|null           $parser
@@ -62,6 +63,7 @@ final class CacheWarmupConfig
         private array $excludePatterns = [],
         private int $limit = 0,
         private bool $progress = false,
+        private array $clientOptions = [],
         private Crawler\Crawler|string|null $crawler = null,
         private array $crawlerOptions = [],
         private Crawler\Strategy\CrawlingStrategy|string|null $strategy = null,
@@ -198,6 +200,38 @@ final class CacheWarmupConfig
     public function disableProgressBar(): self
     {
         $this->progress = false;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getClientOptions(): array
+    {
+        return $this->clientOptions;
+    }
+
+    /**
+     * @param array<string, mixed> $clientOptions
+     */
+    public function setClientOptions(array $clientOptions): self
+    {
+        $this->clientOptions = $clientOptions;
+
+        return $this;
+    }
+
+    public function setClientOption(string $name, mixed $value): self
+    {
+        $this->clientOptions[$name] = $value;
+
+        return $this;
+    }
+
+    public function removeClientOption(string $name): self
+    {
+        unset($this->clientOptions[$name]);
 
         return $this;
     }

--- a/src/DependencyInjection/CompilerPass/ContainerBuilderDebugDumpPass.php
+++ b/src/DependencyInjection/CompilerPass/ContainerBuilderDebugDumpPass.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\DependencyInjection\CompilerPass;
+
+use Symfony\Component\Config;
+use Symfony\Component\DependencyInjection;
+
+/**
+ * Dumps the ContainerBuilder to a cache file so that it can be used by
+ * debugging tools such as the debug:container console command.
+ *
+ * Copyright (C) Fabien Potencier <fabien@symfony.com>
+ *
+ * @author Ryan Weaver <ryan@thatsquality.com>
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @license MIT
+ *
+ * @internal Only to be used for testing purposes
+ *
+ * @codeCoverageIgnore
+ *
+ * @see https://github.com/symfony/framework-bundle/blob/v5.4.35/DependencyInjection/Compiler/ContainerBuilderDebugDumpPass.php
+ * @see https://github.com/symfony/framework-bundle/blob/v5.4.35/LICENSE
+ */
+final readonly class ContainerBuilderDebugDumpPass implements DependencyInjection\Compiler\CompilerPassInterface
+{
+    public function __construct(private string $cachePath) {}
+
+    public function process(DependencyInjection\ContainerBuilder $container): void
+    {
+        $cache = new Config\ConfigCache($this->cachePath, true);
+        if (!$cache->isFresh()) {
+            $cache->write((new DependencyInjection\Dumper\XmlDumper($container))->dump(), $container->getResources());
+        }
+    }
+}

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\DependencyInjection;
+
+use EliasHaeussler\CacheWarmup\Crawler;
+use EliasHaeussler\CacheWarmup\Helper;
+use EliasHaeussler\CacheWarmup\Http;
+use EliasHaeussler\CacheWarmup\Xml;
+use GuzzleHttp\ClientInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log;
+use Symfony\Component\Console;
+use Symfony\Component\DependencyInjection;
+use Symfony\Component\EventDispatcher;
+
+use function array_filter;
+
+/**
+ * ContainerFactory.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ *
+ * @internal
+ */
+final class ContainerFactory
+{
+    /**
+     * @var array<class-string, object>
+     */
+    private readonly array $services;
+
+    /**
+     * @var array<class-string<Crawler\Crawler|Xml\Parser>, DependencyInjection\ContainerInterface>
+     */
+    private array $containers = [];
+
+    public function __construct(
+        Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
+        ?Log\LoggerInterface $logger = null,
+        EventDispatcherInterface $eventDispatcher = new EventDispatcher\EventDispatcher(),
+        Http\Client\ClientFactory $clientFactory = new Http\Client\ClientFactory(),
+    ) {
+        $this->services = array_filter([
+            Console\Output\OutputInterface::class => $output,
+            Log\LoggerInterface::class => $logger,
+            EventDispatcherInterface::class => $eventDispatcher,
+            Http\Client\ClientFactory::class => $clientFactory,
+            ClientInterface::class => $clientFactory->get(),
+        ]);
+    }
+
+    /**
+     * @param class-string<Crawler\Crawler|Xml\Parser> $className
+     */
+    public function buildFor(string $className): DependencyInjection\ContainerInterface
+    {
+        if (isset($this->containers[$className])) {
+            return $this->containers[$className];
+        }
+
+        $container = new DependencyInjection\ContainerBuilder();
+
+        // Register crawler or parser as public service
+        $container->register($className)
+            ->setPublic(true)
+            ->setAutowired(true);
+
+        return $this->containers[$className] = $this->buildWithServices($container);
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    public function buildForTesting(): DependencyInjection\ContainerInterface
+    {
+        $container = new DependencyInjection\ContainerBuilder();
+        $container->addCompilerPass(
+            new CompilerPass\ContainerBuilderDebugDumpPass(
+                Helper\FilesystemHelper::joinPathSegments(
+                    Helper\FilesystemHelper::getWorkingDirectory(),
+                    '.build/container.xml',
+                ),
+            ),
+        );
+
+        return $this->buildWithServices($container);
+    }
+
+    private function buildWithServices(DependencyInjection\ContainerBuilder $container): DependencyInjection\ContainerBuilder
+    {
+        // Register runtime services
+        foreach ($this->services as $alias => $service) {
+            $container
+                ->register($service::class)
+                ->setSynthetic(true)
+                ->setPublic(true)
+            ;
+
+            if ($alias !== $service::class) {
+                $container
+                    ->setAlias($alias, $service::class)
+                    ->setPublic(true)
+                ;
+            }
+        }
+
+        $container->compile();
+
+        // Inject runtime services
+        foreach ($this->services as $service) {
+            $container->set($service::class, $service);
+        }
+
+        return $container;
+    }
+}

--- a/src/Http/Client/ClientFactory.php
+++ b/src/Http/Client/ClientFactory.php
@@ -21,36 +21,40 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes;
+namespace EliasHaeussler\CacheWarmup\Http\Client;
 
-use EliasHaeussler\CacheWarmup\Result;
-use EliasHaeussler\CacheWarmup\Sitemap;
-use EliasHaeussler\CacheWarmup\Xml;
+use EliasHaeussler\CacheWarmup\Helper;
+use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 
 /**
- * DummyParser.
+ * ClientFactory.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
- *
- * @internal
  */
-final class DummyParser implements Xml\Parser
+final readonly class ClientFactory
 {
-    public static ?ClientInterface $client = null;
+    /**
+     * @param array<string, mixed> $defaults
+     */
+    public function __construct(
+        private array $defaults = [],
+    ) {}
 
-    public static ?Sitemap\Sitemap $parsedSitemap = null;
-
-    public function __construct(ClientInterface $client)
+    /**
+     * @param array<string, mixed> $config
+     *
+     * @see https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client
+     */
+    public function get(array $config = []): ClientInterface
     {
-        self::$client = $client;
-    }
+        $mergedConfig = $this->defaults;
 
-    public function parse(Sitemap\Sitemap $sitemap): Result\ParserResult
-    {
-        self::$parsedSitemap = $sitemap;
+        if ([] !== $config) {
+            Helper\ArrayHelper::mergeRecursive($mergedConfig, $config);
+        }
 
-        return new Result\ParserResult();
+        return new Client($mergedConfig);
     }
 }

--- a/tests/build/service-container.php
+++ b/tests/build/service-container.php
@@ -21,36 +21,11 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes;
+use EliasHaeussler\CacheWarmup\DependencyInjection;
+use Psr\Log;
 
-use EliasHaeussler\CacheWarmup\Result;
-use EliasHaeussler\CacheWarmup\Sitemap;
-use EliasHaeussler\CacheWarmup\Xml;
-use GuzzleHttp\ClientInterface;
+require dirname(__DIR__, 2).'/vendor/autoload.php';
 
-/**
- * DummyParser.
- *
- * @author Elias Häußler <elias@haeussler.dev>
- * @license GPL-3.0-or-later
- *
- * @internal
- */
-final class DummyParser implements Xml\Parser
-{
-    public static ?ClientInterface $client = null;
+$containerFactory = new DependencyInjection\ContainerFactory(logger: new Log\NullLogger());
 
-    public static ?Sitemap\Sitemap $parsedSitemap = null;
-
-    public function __construct(ClientInterface $client)
-    {
-        self::$client = $client;
-    }
-
-    public function parse(Sitemap\Sitemap $sitemap): Result\ParserResult
-    {
-        self::$parsedSitemap = $sitemap;
-
-        return new Result\ParserResult();
-    }
-}
+return $containerFactory->buildForTesting();

--- a/tests/unit/CacheWarmerTest.php
+++ b/tests/unit/CacheWarmerTest.php
@@ -78,7 +78,7 @@ final class CacheWarmerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function runPreparesUrlsWithConfiguredStrategy(): void
     {
-        $crawler = new Fixtures\Classes\DummyCrawler($this->eventDispatcher);
+        $crawler = new Fixtures\Classes\DummyCrawler($this->client, $this->eventDispatcher);
         $subject = new Src\CacheWarmer(crawler: $crawler, strategy: new Src\Crawler\Strategy\SortByPriorityStrategy());
 
         $url1 = new Src\Sitemap\Url('https://www.example.org/foo', 0.75);
@@ -97,7 +97,7 @@ final class CacheWarmerTest extends Framework\TestCase
     #[Framework\Attributes\Test]
     public function runDispatchesUrlsPreparedEvent(): void
     {
-        $crawler = new Fixtures\Classes\DummyCrawler($this->eventDispatcher);
+        $crawler = new Fixtures\Classes\DummyCrawler($this->client, $this->eventDispatcher);
         $subject = new Src\CacheWarmer(
             crawler: $crawler,
             strategy: new Src\Crawler\Strategy\SortByPriorityStrategy(),

--- a/tests/unit/Config/Adapter/ConsoleInputConfigAdapterTest.php
+++ b/tests/unit/Config/Adapter/ConsoleInputConfigAdapterTest.php
@@ -46,6 +46,28 @@ final class ConsoleInputConfigAdapterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function getThrowsExceptionIfConfiguredClientOptionsAreInvalid(): void
+    {
+        $subject = $this->getSubject([
+            '--client-options' => 'foo',
+        ]);
+
+        $this->expectExceptionObject(new Src\Exception\OptionsAreMalformed('foo'));
+
+        $subject->get();
+    }
+
+    #[Framework\Attributes\Test]
+    public function getParsesClientOptions(): void
+    {
+        $subject = $this->getSubject([
+            '--client-options' => '{"foo":"baz"}',
+        ]);
+
+        self::assertSame(['foo' => 'baz'], $subject->get()->getClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
     public function getThrowsExceptionIfConfiguredCrawlerOptionsAreInvalid(): void
     {
         $subject = $this->getSubject([
@@ -131,6 +153,7 @@ final class ConsoleInputConfigAdapterTest extends Framework\TestCase
             ],
             '--limit' => 10,
             '--progress' => true,
+            '--client-options' => '{"foo":"baz"}',
             '--crawler' => Tests\Fixtures\Classes\DummyCrawler::class,
             '--crawler-options' => '{"foo":"baz"}',
             '--strategy' => Src\Crawler\Strategy\SortByChangeFrequencyStrategy::getName(),
@@ -159,6 +182,7 @@ final class ConsoleInputConfigAdapterTest extends Framework\TestCase
             ],
             10,
             true,
+            ['foo' => 'baz'],
             Tests\Fixtures\Classes\DummyCrawler::class,
             ['foo' => 'baz'],
             Src\Crawler\Strategy\SortByChangeFrequencyStrategy::getName(),

--- a/tests/unit/Config/Adapter/EnvironmentVariablesConfigAdapterTest.php
+++ b/tests/unit/Config/Adapter/EnvironmentVariablesConfigAdapterTest.php
@@ -62,6 +62,30 @@ final class EnvironmentVariablesConfigAdapterTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function getThrowsExceptionIfConfiguredClientOptionsAreInvalid(): void
+    {
+        $this->expectExceptionObject(new Src\Exception\OptionsAreMalformed('foo'));
+
+        $this->testWithEnvironment(
+            fn () => $this->subject->get(),
+            [
+                'CACHE_WARMUP_CLIENT_OPTIONS' => 'foo',
+            ],
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function getParsesClientOptions(): void
+    {
+        $this->testWithEnvironment(
+            fn () => self::assertSame(['foo' => 'baz'], $this->subject->get()->getClientOptions()),
+            [
+                'CACHE_WARMUP_CLIENT_OPTIONS' => '{"foo":"baz"}',
+            ],
+        );
+    }
+
+    #[Framework\Attributes\Test]
     public function getThrowsExceptionIfConfiguredCrawlerOptionsAreInvalid(): void
     {
         $this->expectExceptionObject(new Src\Exception\OptionsAreMalformed('foo'));
@@ -171,6 +195,7 @@ final class EnvironmentVariablesConfigAdapterTest extends Framework\TestCase
             'CACHE_WARMUP_EXCLUDE_PATTERNS' => '#foo#,*foo*',
             'CACHE_WARMUP_LIMIT' => '10',
             'CACHE_WARMUP_PROGRESS' => 'true',
+            'CACHE_WARMUP_CLIENT_OPTIONS' => '{"foo":"baz"}',
             'CACHE_WARMUP_CRAWLER' => Tests\Fixtures\Classes\DummyCrawler::class,
             'CACHE_WARMUP_CRAWLER_OPTIONS' => '{"foo":"baz"}',
             'CACHE_WARMUP_STRATEGY' => Src\Crawler\Strategy\SortByChangeFrequencyStrategy::getName(),
@@ -199,6 +224,7 @@ final class EnvironmentVariablesConfigAdapterTest extends Framework\TestCase
             ],
             10,
             true,
+            ['foo' => 'baz'],
             Tests\Fixtures\Classes\DummyCrawler::class,
             ['foo' => 'baz'],
             Src\Crawler\Strategy\SortByChangeFrequencyStrategy::getName(),

--- a/tests/unit/Config/Adapter/FileConfigAdapterTest.php
+++ b/tests/unit/Config/Adapter/FileConfigAdapterTest.php
@@ -90,6 +90,7 @@ final class FileConfigAdapterTest extends Framework\TestCase
             ],
             10,
             true,
+            ['foo' => 'baz'],
             Tests\Fixtures\Classes\DummyCrawler::class,
             ['foo' => 'baz'],
             Src\Crawler\Strategy\SortByChangeFrequencyStrategy::getName(),

--- a/tests/unit/Config/CacheWarmupConfigTest.php
+++ b/tests/unit/Config/CacheWarmupConfigTest.php
@@ -54,6 +54,7 @@ final class CacheWarmupConfigTest extends Framework\TestCase
             ],
             10,
             true,
+            ['foo' => 'baz'],
             Tests\Fixtures\Classes\DummyCrawler::class,
             ['foo' => 'baz'],
             Src\Crawler\Strategy\SortByChangeFrequencyStrategy::getName(),
@@ -121,6 +122,27 @@ final class CacheWarmupConfigTest extends Framework\TestCase
         $this->subject->disableLimit();
 
         self::assertSame(0, $this->subject->getLimit());
+    }
+
+    #[Framework\Attributes\Test]
+    public function setClientOptionAppliesGivenClientOptionToClientOptions(): void
+    {
+        $this->subject->setClientOption('baz', 'foo');
+
+        $expected = [
+            'foo' => 'baz',
+            'baz' => 'foo',
+        ];
+
+        self::assertSame($expected, $this->subject->getClientOptions());
+    }
+
+    #[Framework\Attributes\Test]
+    public function removeClientOptionRemovesGivenClientOptionFromClientOptions(): void
+    {
+        $this->subject->removeClientOption('foo');
+
+        self::assertSame([], $this->subject->getClientOptions());
     }
 
     #[Framework\Attributes\Test]
@@ -204,6 +226,7 @@ final class CacheWarmupConfigTest extends Framework\TestCase
             ],
             50,
             false,
+            ['dummy' => 'foo'],
             Tests\Fixtures\Classes\DummyLoggingCrawler::class,
             ['dummy' => 'foo'],
             Src\Crawler\Strategy\SortByLastModificationDateStrategy::getName(),
@@ -232,6 +255,10 @@ final class CacheWarmupConfigTest extends Framework\TestCase
             ],
             50,
             true,
+            [
+                'foo' => 'baz',
+                'dummy' => 'foo',
+            ],
             Tests\Fixtures\Classes\DummyLoggingCrawler::class,
             [
                 'foo' => 'baz',
@@ -265,6 +292,7 @@ final class CacheWarmupConfigTest extends Framework\TestCase
             'excludePatterns' => [],
             'limit' => 10,
             'progress' => false,
+            'clientOptions' => [],
             'crawler' => null,
             'crawlerOptions' => [],
             'strategy' => null,

--- a/tests/unit/DependencyInjection/ContainerFactoryTest.php
+++ b/tests/unit/DependencyInjection/ContainerFactoryTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\DependencyInjection;
+
+use EliasHaeussler\CacheWarmup as Src;
+use EliasHaeussler\CacheWarmup\Tests;
+use GuzzleHttp\ClientInterface;
+use PHPUnit\Framework;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log;
+use Symfony\Component\Console;
+use Symfony\Component\EventDispatcher;
+
+/**
+ * ContainerFactoryTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\DependencyInjection\ContainerFactory::class)]
+final class ContainerFactoryTest extends Framework\TestCase
+{
+    private Console\Output\NullOutput $output;
+    private Log\NullLogger $logger;
+    private EventDispatcher\EventDispatcher $eventDispatcher;
+    private Src\Http\Client\ClientFactory $clientFactory;
+    private Src\DependencyInjection\ContainerFactory $subject;
+
+    public function setUp(): void
+    {
+        $this->output = new Console\Output\NullOutput();
+        $this->logger = new Log\NullLogger();
+        $this->eventDispatcher = new EventDispatcher\EventDispatcher();
+        $this->clientFactory = new Src\Http\Client\ClientFactory();
+        $this->subject = new Src\DependencyInjection\ContainerFactory(
+            $this->output,
+            $this->logger,
+            $this->eventDispatcher,
+            $this->clientFactory,
+        );
+    }
+
+    #[Framework\Attributes\Test]
+    public function buildForReturnsCachedContainer(): void
+    {
+        $crawler = $this->subject->buildFor(Tests\Fixtures\Classes\DummyCrawler::class);
+
+        self::assertSame($crawler, $this->subject->buildFor(Tests\Fixtures\Classes\DummyCrawler::class));
+    }
+
+    #[Framework\Attributes\Test]
+    public function buildForRegistersAutowiredServiceForGivenClassName(): void
+    {
+        $actual = $this->subject->buildFor(Tests\Fixtures\Classes\DummyCrawler::class);
+
+        /* @phpstan-ignore symfonyContainer.serviceNotFound */
+        $crawler = $actual->get(Tests\Fixtures\Classes\DummyCrawler::class);
+
+        self::assertInstanceOf(Tests\Fixtures\Classes\DummyCrawler::class, $crawler);
+        self::assertSame($this->eventDispatcher, $crawler->eventDispatcher);
+        self::assertEquals($this->clientFactory->get(), Tests\Fixtures\Classes\DummyCrawler::$client);
+    }
+
+    #[Framework\Attributes\Test]
+    public function buildForRegistersComponentsAsServices(): void
+    {
+        $actual = $this->subject->buildFor(Tests\Fixtures\Classes\DummyCrawler::class);
+
+        self::assertSame($this->output, $actual->get(Console\Output\OutputInterface::class));
+        self::assertSame($this->logger, $actual->get(Log\LoggerInterface::class));
+        self::assertSame($this->eventDispatcher, $actual->get(EventDispatcherInterface::class));
+        self::assertSame($this->clientFactory, $actual->get(Src\Http\Client\ClientFactory::class));
+        self::assertEquals($this->clientFactory->get(), $actual->get(ClientInterface::class));
+    }
+
+    protected function tearDown(): void
+    {
+        Tests\Fixtures\Classes\DummyCrawler::$client = null;
+    }
+}

--- a/tests/unit/Fixtures/Classes/DummyCrawler.php
+++ b/tests/unit/Fixtures/Classes/DummyCrawler.php
@@ -25,6 +25,7 @@ namespace EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes;
 
 use EliasHaeussler\CacheWarmup\Crawler;
 use EliasHaeussler\CacheWarmup\Result;
+use GuzzleHttp\ClientInterface;
 use Psr\EventDispatcher;
 use Psr\Http\Message;
 
@@ -40,6 +41,8 @@ use function array_shift;
  */
 class DummyCrawler implements Crawler\Crawler
 {
+    public static ?ClientInterface $client = null;
+
     /**
      * @var list<Message\UriInterface>
      */
@@ -51,8 +54,11 @@ class DummyCrawler implements Crawler\Crawler
     public static array $resultStack = [];
 
     public function __construct(
+        ClientInterface $client,
         public readonly EventDispatcher\EventDispatcherInterface $eventDispatcher,
-    ) {}
+    ) {
+        self::$client = $client;
+    }
 
     public function crawl(array $urls): Result\CacheWarmupResult
     {

--- a/tests/unit/Fixtures/ConfigFiles/valid_config.json
+++ b/tests/unit/Fixtures/ConfigFiles/valid_config.json
@@ -13,6 +13,9 @@
 	],
 	"limit": 10,
 	"progress": true,
+	"clientOptions": {
+		"foo": "baz"
+	},
 	"crawler": "EliasHaeussler\\CacheWarmup\\Tests\\Fixtures\\Classes\\DummyCrawler",
 	"crawlerOptions": {
 		"foo": "baz"

--- a/tests/unit/Fixtures/ConfigFiles/valid_config.yaml
+++ b/tests/unit/Fixtures/ConfigFiles/valid_config.yaml
@@ -9,6 +9,8 @@ excludePatterns:
   - '*foo*'
 limit: 10
 progress: true
+clientOptions:
+  foo: baz
 crawler: EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes\DummyCrawler
 crawlerOptions:
   foo: baz

--- a/tests/unit/Fixtures/ConfigFiles/valid_config.yml
+++ b/tests/unit/Fixtures/ConfigFiles/valid_config.yml
@@ -9,6 +9,8 @@ excludePatterns:
   - '*foo*'
 limit: 10
 progress: true
+clientOptions:
+  foo: baz
 crawler: EliasHaeussler\CacheWarmup\Tests\Fixtures\Classes\DummyCrawler
 crawlerOptions:
   foo: baz

--- a/tests/unit/Http/Client/ClientFactoryTest.php
+++ b/tests/unit/Http/Client/ClientFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2024 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Http\Client;
+
+use EliasHaeussler\CacheWarmup as Src;
+use GuzzleHttp\Client;
+use PHPUnit\Framework;
+
+/**
+ * ClientFactoryTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Http\Client\ClientFactory::class)]
+final class ClientFactoryTest extends Framework\TestCase
+{
+    private Src\Http\Client\ClientFactory $subject;
+
+    public function setUp(): void
+    {
+        $this->subject = new Src\Http\Client\ClientFactory([
+            'foo' => 'baz',
+        ]);
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsClientWithDefaultConfig(): void
+    {
+        $expected = new Client([
+            'foo' => 'baz',
+        ]);
+
+        self::assertEquals($expected, $this->subject->get());
+    }
+
+    #[Framework\Attributes\Test]
+    public function getReturnsClientWithMergedConfig(): void
+    {
+        $expected = new Client([
+            'foo' => 'baz',
+            'another' => 'foo',
+        ]);
+
+        self::assertEquals($expected, $this->subject->get(['another' => 'foo']));
+    }
+}


### PR DESCRIPTION
This PR introduces a new `ClientFactory`. It is constructed from a new configuration option `clientOptions` and provides a shared Guzzle client for crawlers and parsers. In addition, the existing DI service container usage for crawlers is now extended to parsers by a new `ContainerFactory`. The service container includes the shared Guzzle client as well.