### PR TITLE
[!!!][TASK] Drop `client_config` crawler option in favor of `clientOptions`

### DIFF
--- a/docs/config-reference/crawler-options.md
+++ b/docs/config-reference/crawler-options.md
@@ -75,61 +75,6 @@ Both default crawlers are implemented as configurable crawlers:
 
 The following configuration options are currently available for both crawlers:
 
-### `client_config` <Badge type="tip" text="1.2.0+" />
-
-<small>🎨&nbsp;Type: `array<string, mixed>` &middot; 🐝&nbsp;Default: `[]`</small>
-
-> Optional [configuration](https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client)
-> used when instantiating a new Guzzle client.
-
-::: code-group
-
-```bash [CLI]
-./cache-warmup.phar --crawler-options '{"client_config": {"auth": ["username", "password"]}}'
-```
-
-```json [JSON]
-{
-    "crawlerOptions": {
-        "client_config": {
-            "auth": [
-                "username",
-                "password"
-            ]
-        }
-    }
-}
-```
-
-```php [PHP]
-use EliasHaeussler\CacheWarmup;
-
-return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
-    $config->setCrawlerOption('client_config', [
-        'auth' => [
-            'username',
-            'password',
-        ],
-    ]);
-
-    return $config;
-};
-```
-
-```yaml [YAML]
-crawlerOptions:
-  client_config:
-    auth:
-      - username
-      - password
-```
-
-```bash [.env]
-CACHE_WARMUP_CRAWLER_OPTIONS='{"client_config": {"auth": ["username", "password"]}}'
-```
-
-:::
-
 ### `concurrency` <Badge type="tip" text="0.7.13+" />
 
 <small>🎨&nbsp;Type: `integer` &middot; 🐝&nbsp;Default: `3`</small>

--- a/docs/config-reference/parser-options.md
+++ b/docs/config-reference/parser-options.md
@@ -26,13 +26,13 @@ make sure to pass them as **JSON-encoded string**.
 ::: code-group
 
 ```bash [CLI]
-./cache-warmup.phar --parser-options '{"client_config": {"proxy": "http://localhost:8125"}}'
+./cache-warmup.phar --parser-options '{"request_options": {"proxy": "http://localhost:8125"}}'
 ```
 
 ```json [JSON]
 {
     "parserOptions": {
-        "client_config": {
+        "request_options": {
             "proxy": "http://localhost:8125"
         }
     }
@@ -43,7 +43,7 @@ make sure to pass them as **JSON-encoded string**.
 use EliasHaeussler\CacheWarmup;
 
 return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
-    $config->setParserOption('client_config', [
+    $config->setParserOption('request_options', [
         'proxy' => 'http://localhost:8125',
     ]);
 
@@ -53,12 +53,12 @@ return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
 
 ```yaml [YAML]
 parserOptions:
-  client_config:
+  request_options:
     proxy: 'http://localhost:8125'
 ```
 
 ```bash [.env]
-CACHE_WARMUP_PARSER_OPTIONS='{"client_config": {"proxy": "http://localhost:8125"}}'
+CACHE_WARMUP_PARSER_OPTIONS='{"request_options": {"proxy": "http://localhost:8125"}}'
 ```
 
 :::
@@ -70,61 +70,6 @@ The default parser is implemented as configurable parser:
 * [`EliasHaeussler\CacheWarmup\Xml\SitemapXmlParser`](../../src/Xml/SitemapXmlParser.php)
 
 The following configuration options are currently available for the default parser:
-
-### `client_config` <Badge type="tip" text="4.0+" />
-
-<small>🎨&nbsp;Type: `array<string, mixed>` &middot; 🐝&nbsp;Default: `[]`</small>
-
-> Optional [configuration](https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client)
-> used when instantiating a new Guzzle client.
-
-::: code-group
-
-```bash [CLI]
-./cache-warmup.phar --parser-options '{"client_config": {"auth": ["username", "password"]}}'
-```
-
-```json [JSON]
-{
-    "parserOptions": {
-        "client_config": {
-            "auth": [
-                "username",
-                "password"
-            ]
-        }
-    }
-}
-```
-
-```php [PHP]
-use EliasHaeussler\CacheWarmup;
-
-return static function (CacheWarmup\Config\CacheWarmupConfig $config) {
-    $config->setParserOption('client_config', [
-        'auth' => [
-            'username',
-            'password',
-        ],
-    ]);
-
-    return $config;
-};
-```
-
-```yaml [YAML]
-parserOptions:
-  client_config:
-    auth:
-      - username
-      - password
-```
-
-```bash [.env]
-CACHE_WARMUP_PARSER_OPTIONS='{"client_config": {"auth": ["username", "password"]}}'
-```
-
-:::
 
 ### `request_headers` <Badge type="tip" text="4.0+" />
 

--- a/src/Crawler/ConcurrentCrawler.php
+++ b/src/Crawler/ConcurrentCrawler.php
@@ -42,7 +42,6 @@ use Psr\Log;
  *     request_method: string,
  *     request_headers: array<string, string>,
  *     request_options: array<string, mixed>,
- *     client_config: array<string, mixed>,
  *     write_response_body: bool,
  * }>
  */
@@ -58,7 +57,7 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
 
     public function __construct(
         array $options = [],
-        private readonly ?ClientInterface $client = null,
+        private readonly ClientInterface $client = new Client(),
         private ?Log\LoggerInterface $logger = null,
         private readonly ?EventDispatcher\EventDispatcherInterface $eventDispatcher = null,
     ) {
@@ -77,12 +76,9 @@ final class ConcurrentCrawler extends AbstractConfigurableCrawler implements Log
             $handlers[] = $logHandler;
         }
 
-        // Create new client
-        $client = $this->client ?? new Client($this->options['client_config']);
-
         // Start crawling
         try {
-            $this->createPool($urls, $client, $handlers, $this->stopOnFailure)->promise()->wait();
+            $this->createPool($urls, $this->client, $handlers, $this->stopOnFailure)->promise()->wait();
         } catch (Promise\CancellationException) {
             $result->setCancelled(true);
         }

--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -64,11 +64,6 @@ trait ConcurrentCrawlerTrait
             ->default([])
         ;
 
-        $optionsResolver->define('client_config')
-            ->allowedTypes('array')
-            ->default([])
-        ;
-
         $optionsResolver->define('write_response_body')
             ->allowedTypes('bool')
             ->default(false)

--- a/src/Crawler/OutputtingCrawler.php
+++ b/src/Crawler/OutputtingCrawler.php
@@ -45,7 +45,6 @@ use function count;
  *     request_method: string,
  *     request_headers: array<string, string>,
  *     request_options: array<string, mixed>,
- *     client_config: array<string, mixed>,
  *     write_response_body: bool,
  * }>
  */
@@ -61,7 +60,7 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
 
     public function __construct(
         array $options = [],
-        private readonly ?ClientInterface $client = null,
+        private readonly ClientInterface $client = new Client(),
         private Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
         private ?Log\LoggerInterface $logger = null,
         private readonly ?EventDispatcher\EventDispatcherInterface $eventDispatcher = null,
@@ -91,11 +90,8 @@ final class OutputtingCrawler extends AbstractConfigurableCrawler implements Log
             $handlers[] = $logHandler;
         }
 
-        // Create new client
-        $client = $this->client ?? new Client($this->options['client_config']);
-
         // Create request pool
-        $pool = $this->createPool($urls, $client, $handlers, $this->stopOnFailure);
+        $pool = $this->createPool($urls, $this->client, $handlers, $this->stopOnFailure);
 
         // Start crawling
         try {

--- a/src/Xml/SitemapXmlParser.php
+++ b/src/Xml/SitemapXmlParser.php
@@ -57,7 +57,6 @@ use function unlink;
  * @license GPL-3.0-or-later
  *
  * @phpstan-type ParserOptions array{
- *     client_config: array<string, mixed>,
  *     request_headers: array<string, string>,
  *     request_options: array<string, mixed>,
  * }
@@ -82,7 +81,7 @@ final class SitemapXmlParser implements ConfigurableParser
      */
     public function __construct(
         array $options = [],
-        private readonly ?ClientInterface $client = null,
+        private readonly ClientInterface $client = new Client(),
     ) {
         $this->optionsResolver = $this->createOptionsResolver();
         $this->sitemapConverter = new Node\SitemapNodeConverter();
@@ -194,8 +193,7 @@ final class SitemapXmlParser implements ConfigurableParser
         $requestOptions = $this->options['request_options'];
         $requestOptions[RequestOptions::SINK] = $filename;
 
-        $client = $this->client ?? new Client($this->options['client_config']);
-        $client->send($request, $requestOptions);
+        $this->client->send($request, $requestOptions);
 
         return $filename;
     }
@@ -217,11 +215,6 @@ final class SitemapXmlParser implements ConfigurableParser
     private function createOptionsResolver(): OptionsResolver\OptionsResolver
     {
         $optionsResolver = new OptionsResolver\OptionsResolver();
-
-        $optionsResolver->define('client_config')
-            ->allowedTypes('array')
-            ->default([])
-        ;
 
         $optionsResolver->define('request_headers')
             ->allowedTypes('array')

--- a/tests/unit/Crawler/ConcurrentCrawlerTest.php
+++ b/tests/unit/Crawler/ConcurrentCrawlerTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
 use EliasHaeussler\CacheWarmup as Src;
 use EliasHaeussler\CacheWarmup\Tests;
 use EliasHaeussler\TransientLogger;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework;
@@ -57,45 +56,6 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function crawlInstantiatesClientWithGivenClientConfig(): void
-    {
-        $this->mockHandler->append(new Psr7\Response());
-
-        $subject = new Src\Crawler\ConcurrentCrawler(
-            [
-                'client_config' => [
-                    'handler' => $this->mockHandler,
-                ],
-            ],
-        );
-
-        self::assertNull($this->mockHandler->getLastRequest());
-
-        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
-
-        self::assertNotNull($this->mockHandler->getLastRequest());
-    }
-
-    #[Framework\Attributes\Test]
-    public function crawlIgnoresGivenClientConfigIfInstantiatedClientIsPassed(): void
-    {
-        $subject = new Src\Crawler\ConcurrentCrawler(
-            [
-                'client_config' => [
-                    'handler' => $this->mockHandler,
-                ],
-            ],
-            new Client(),
-        );
-
-        self::assertNull($this->mockHandler->getLastRequest());
-
-        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
-
-        self::assertNull($this->mockHandler->getLastRequest());
-    }
-
-    #[Framework\Attributes\Test]
     public function crawlDoesNotWritesResponseBodyByDefault(): void
     {
         $this->mockHandler->append(new Psr7\Response());
@@ -115,16 +75,11 @@ final class ConcurrentCrawlerTest extends Framework\TestCase
     {
         $this->mockHandler->append(new Psr7\Response());
 
-        $subject = new Src\Crawler\ConcurrentCrawler(
-            [
-                'client_config' => [
-                    'handler' => $this->mockHandler,
-                ],
-                'write_response_body' => true,
-            ],
-        );
+        $this->subject->setOptions([
+            'write_response_body' => true,
+        ]);
 
-        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
+        $this->subject->crawl([new Psr7\Uri('https://www.example.org')]);
 
         $lastOptions = $this->mockHandler->getLastOptions();
         $sink = $lastOptions[RequestOptions::SINK] ?? null;

--- a/tests/unit/Crawler/OutputtingCrawlerTest.php
+++ b/tests/unit/Crawler/OutputtingCrawlerTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\CacheWarmup\Tests\Crawler;
 use EliasHaeussler\CacheWarmup as Src;
 use EliasHaeussler\CacheWarmup\Tests;
 use EliasHaeussler\TransientLogger;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework;
@@ -61,47 +60,6 @@ final class OutputtingCrawlerTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function crawlInstantiatesClientWithGivenClientConfig(): void
-    {
-        $this->mockHandler->append(new Psr7\Response());
-
-        $subject = new Src\Crawler\OutputtingCrawler(
-            [
-                'client_config' => [
-                    'handler' => $this->mockHandler,
-                ],
-            ],
-        );
-        $subject->setOutput($this->output);
-
-        self::assertNull($this->mockHandler->getLastRequest());
-
-        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
-
-        self::assertNotNull($this->mockHandler->getLastRequest());
-    }
-
-    #[Framework\Attributes\Test]
-    public function crawlIgnoresGivenClientConfigIfInstantiatedClientIsPassed(): void
-    {
-        $subject = new Src\Crawler\OutputtingCrawler(
-            [
-                'client_config' => [
-                    'handler' => $this->mockHandler,
-                ],
-            ],
-            new Client(),
-        );
-        $subject->setOutput($this->output);
-
-        self::assertNull($this->mockHandler->getLastRequest());
-
-        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
-
-        self::assertNull($this->mockHandler->getLastRequest());
-    }
-
-    #[Framework\Attributes\Test]
     public function crawlDoesNotWritesResponseBodyByDefault(): void
     {
         $this->mockHandler->append(new Psr7\Response());
@@ -122,16 +80,11 @@ final class OutputtingCrawlerTest extends Framework\TestCase
     {
         $this->mockHandler->append(new Psr7\Response());
 
-        $subject = new Src\Crawler\ConcurrentCrawler(
-            [
-                'client_config' => [
-                    'handler' => $this->mockHandler,
-                ],
-                'write_response_body' => true,
-            ],
-        );
+        $this->subject->setOptions([
+            'write_response_body' => true,
+        ]);
 
-        $subject->crawl([new Psr7\Uri('https://www.example.org')]);
+        $this->subject->crawl([new Psr7\Uri('https://www.example.org')]);
 
         $lastOptions = $this->mockHandler->getLastOptions();
         $sink = $lastOptions[RequestOptions::SINK] ?? null;

--- a/tests/unit/Xml/SitemapXmlParserTest.php
+++ b/tests/unit/Xml/SitemapXmlParserTest.php
@@ -26,7 +26,6 @@ namespace EliasHaeussler\CacheWarmup\Tests\Xml;
 use DateTimeImmutable;
 use EliasHaeussler\CacheWarmup as Src;
 use EliasHaeussler\CacheWarmup\Tests;
-use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\RequestOptions;
 use PHPUnit\Framework;
@@ -172,22 +171,6 @@ final class SitemapXmlParserTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function parseRespectsConfiguredClientConfig(): void
-    {
-        $this->mockSitemapRequest('valid_sitemap_4');
-
-        $subject = new Src\Xml\SitemapXmlParser([
-            'client_config' => [
-                'handler' => HandlerStack::create($this->mockHandler),
-            ],
-        ]);
-
-        $subject->parse($this->sitemap);
-
-        self::assertNotNull($this->mockHandler->getLastRequest());
-    }
-
-    #[Framework\Attributes\Test]
     public function parseRespectsConfiguredRequestHeaders(): void
     {
         $this->mockSitemapRequest('valid_sitemap_4');
@@ -260,7 +243,6 @@ final class SitemapXmlParserTest extends Framework\TestCase
         $this->expectException(OptionsResolver\Exception\UndefinedOptionsException::class);
 
         $this->subject->setOptions([
-            'client_config' => [],
             'foo' => 'baz',
         ]);
     }
@@ -275,7 +257,6 @@ final class SitemapXmlParserTest extends Framework\TestCase
         ]);
 
         $expected = [
-            'client_config' => [],
             'request_headers' => [
                 'foo' => 'baz',
             ],


### PR DESCRIPTION
This PR drops the `client_config` crawler options and parser option. They are replaced by the new `clientOptions` configuration option since they're used in the shared Guzzle client.