### PR TITLE
[FEATURE] Allow more fine-grained control in `RequestFactory`

### DIFF
--- a/src/Crawler/ConcurrentCrawlerTrait.php
+++ b/src/Crawler/ConcurrentCrawlerTrait.php
@@ -80,17 +80,18 @@ trait ConcurrentCrawlerTrait
         array $handlers = [],
         bool $stopOnFailure = false,
     ): Pool {
-        $requestFactory = new Http\Message\RequestFactory(
-            $this->options['request_method'],
-            $this->options['request_headers'],
-        );
         $options = $this->options['request_options'];
+        $requests = Http\Message\RequestFactory::create($this->options['request_method'])
+            ->withHeaders($this->options['request_headers'])
+            ->withUserAgent(true)
+            ->createRequests($urls)
+        ;
 
         if (!$this->options['write_response_body'] && !array_key_exists(RequestOptions::SINK, $options)) {
             $options[RequestOptions::SINK] = new Http\Message\Stream\NullStream();
         }
 
-        return Http\Message\RequestPoolFactory::create($requestFactory->buildIterable($urls))
+        return Http\Message\RequestPoolFactory::create($requests)
             ->withClient($client)
             ->withConcurrency($this->options['concurrency'])
             ->withOptions($options)

--- a/src/Xml/SitemapXmlParser.php
+++ b/src/Xml/SitemapXmlParser.php
@@ -188,8 +188,12 @@ final class SitemapXmlParser implements ConfigurableParser
     {
         $filename = $this->createTemporaryFilename((string) $uri);
 
-        $requestFactory = new Http\Message\RequestFactory('GET', $this->options['request_headers']);
-        $request = $requestFactory->build($uri);
+        $request = Http\Message\RequestFactory::create('GET')
+            ->withHeaders($this->options['request_headers'])
+            ->withUserAgent(true)
+            ->createRequest($uri)
+        ;
+
         $requestOptions = $this->options['request_options'];
         $requestOptions[RequestOptions::SINK] = $filename;
 

--- a/tests/unit/Http/Message/RequestPoolFactoryTest.php
+++ b/tests/unit/Http/Message/RequestPoolFactoryTest.php
@@ -59,7 +59,7 @@ final class RequestPoolFactoryTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
-    public function createReturnsObjectForGivenRequests(): void
+    public function createPoolReturnsObjectForGivenRequests(): void
     {
         $visitedUrls = [];
         $response = function (Message\RequestInterface $request) use (&$visitedUrls) {


### PR DESCRIPTION
This PR changes the way how requests are built with `RequestFactory`. The usage of request headers and especially inclusion of `User-Agent` header can now better be controlled by using dedicated methods.