### PR TITLE
[!!!][FEATURE] Dispatch events if services are constructed

### DIFF
--- a/docs/api/events.md
+++ b/docs/api/events.md
@@ -15,6 +15,12 @@ actions. This page lists all currently available events.
 
 ## Parser
 
+### [`ParserConstructed`](../../src/Event/ParserConstructed.php) <Badge type="tip" text="4.0+" />
+
+<small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
+
+> Dispatched if an XML parser is constructed by the parser factory.
+
 ### [`SitemapAdded`](../../src/Event/SitemapAdded.php) <Badge type="tip" text="3.2+" />
 
 <small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
@@ -54,6 +60,12 @@ actions. This page lists all currently available events.
 > [exclude pattern](../config-reference/exclude.md).
 
 ## Crawler
+
+### [`CrawlerConstructed`](../../src/Event/CrawlerConstructed.php) <Badge type="tip" text="4.0+" />
+
+<small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
+
+> Dispatched if a crawler is constructed by the crawler factory.
 
 ### [`UrlsPrepared`](../../src/Event/UrlsPrepared.php) <Badge type="tip" text="3.2+" />
 
@@ -95,3 +107,11 @@ This event is only dispatched if the configured crawler utilizes the
 <small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
 
 > Dispatched once crawling is finished.
+
+## HTTP
+
+### [`ClientConstructed`](../../src/Event/ClientConstructed.php) <Badge type="tip" text="4.0+" />
+
+<small>✅&nbsp;Console command &middot; ✅&nbsp;PHP API</small>
+
+> Dispatched if an HTTP client is constructed by the client factory.

--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -434,7 +434,7 @@ HELP);
             $output,
             $logger,
             $this->eventDispatcher,
-            new Http\Client\ClientFactory($this->config->getClientOptions()),
+            new Http\Client\ClientFactory($this->eventDispatcher, $this->config->getClientOptions()),
         );
 
         // Create factories

--- a/src/Crawler/CrawlerFactory.php
+++ b/src/Crawler/CrawlerFactory.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Crawler;
 
 use EliasHaeussler\CacheWarmup\DependencyInjection;
+use EliasHaeussler\CacheWarmup\Event;
 use EliasHaeussler\CacheWarmup\Exception;
+use Psr\EventDispatcher;
 use Psr\Log;
 use Symfony\Component\Console;
 
@@ -80,6 +82,9 @@ final readonly class CrawlerFactory
         if ($crawler instanceof StoppableCrawler) {
             $crawler->stopOnFailure($this->stopOnFailure);
         }
+
+        $eventDispatcher = $container->get(EventDispatcher\EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new Event\CrawlerConstructed($crawler));
 
         return $crawler;
     }

--- a/src/DependencyInjection/ContainerFactory.php
+++ b/src/DependencyInjection/ContainerFactory.php
@@ -60,8 +60,10 @@ final class ContainerFactory
         Console\Output\OutputInterface $output = new Console\Output\ConsoleOutput(),
         ?Log\LoggerInterface $logger = null,
         EventDispatcherInterface $eventDispatcher = new EventDispatcher\EventDispatcher(),
-        Http\Client\ClientFactory $clientFactory = new Http\Client\ClientFactory(),
+        ?Http\Client\ClientFactory $clientFactory = null,
     ) {
+        $clientFactory ??= new Http\Client\ClientFactory($eventDispatcher);
+
         $this->services = array_filter([
             Console\Output\OutputInterface::class => $output,
             Log\LoggerInterface::class => $logger,

--- a/src/Event/ClientConstructed.php
+++ b/src/Event/ClientConstructed.php
@@ -21,47 +21,24 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Http\Client;
+namespace EliasHaeussler\CacheWarmup\Event;
 
-use EliasHaeussler\CacheWarmup\Event;
-use EliasHaeussler\CacheWarmup\Helper;
-use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
-use Psr\EventDispatcher;
 
 /**
- * ClientFactory.
+ * ClientConstructed.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final readonly class ClientFactory
+final readonly class ClientConstructed
 {
-    /**
-     * @param array<string, mixed> $defaults
-     */
     public function __construct(
-        private EventDispatcher\EventDispatcherInterface $eventDispatcher,
-        private array $defaults = [],
+        private ClientInterface $client,
     ) {}
 
-    /**
-     * @param array<string, mixed> $config
-     *
-     * @see https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client
-     */
-    public function get(array $config = []): ClientInterface
+    public function client(): ClientInterface
     {
-        $mergedConfig = $this->defaults;
-
-        if ([] !== $config) {
-            Helper\ArrayHelper::mergeRecursive($mergedConfig, $config);
-        }
-
-        $client = new Client($mergedConfig);
-
-        $this->eventDispatcher->dispatch(new Event\ClientConstructed($client));
-
-        return $client;
+        return $this->client;
     }
 }

--- a/src/Event/CrawlerConstructed.php
+++ b/src/Event/CrawlerConstructed.php
@@ -21,47 +21,24 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Http\Client;
+namespace EliasHaeussler\CacheWarmup\Event;
 
-use EliasHaeussler\CacheWarmup\Event;
-use EliasHaeussler\CacheWarmup\Helper;
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
-use Psr\EventDispatcher;
+use EliasHaeussler\CacheWarmup\Crawler;
 
 /**
- * ClientFactory.
+ * CrawlerConstructed.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final readonly class ClientFactory
+final readonly class CrawlerConstructed
 {
-    /**
-     * @param array<string, mixed> $defaults
-     */
     public function __construct(
-        private EventDispatcher\EventDispatcherInterface $eventDispatcher,
-        private array $defaults = [],
+        private Crawler\Crawler $crawler,
     ) {}
 
-    /**
-     * @param array<string, mixed> $config
-     *
-     * @see https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client
-     */
-    public function get(array $config = []): ClientInterface
+    public function crawler(): Crawler\Crawler
     {
-        $mergedConfig = $this->defaults;
-
-        if ([] !== $config) {
-            Helper\ArrayHelper::mergeRecursive($mergedConfig, $config);
-        }
-
-        $client = new Client($mergedConfig);
-
-        $this->eventDispatcher->dispatch(new Event\ClientConstructed($client));
-
-        return $client;
+        return $this->crawler;
     }
 }

--- a/src/Event/ParserConstructed.php
+++ b/src/Event/ParserConstructed.php
@@ -21,47 +21,24 @@ declare(strict_types=1);
  * along with this program. If not, see <https://www.gnu.org/licenses/>.
  */
 
-namespace EliasHaeussler\CacheWarmup\Http\Client;
+namespace EliasHaeussler\CacheWarmup\Event;
 
-use EliasHaeussler\CacheWarmup\Event;
-use EliasHaeussler\CacheWarmup\Helper;
-use GuzzleHttp\Client;
-use GuzzleHttp\ClientInterface;
-use Psr\EventDispatcher;
+use EliasHaeussler\CacheWarmup\Xml;
 
 /**
- * ClientFactory.
+ * ParserConstructed.
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final readonly class ClientFactory
+final readonly class ParserConstructed
 {
-    /**
-     * @param array<string, mixed> $defaults
-     */
     public function __construct(
-        private EventDispatcher\EventDispatcherInterface $eventDispatcher,
-        private array $defaults = [],
+        private Xml\Parser $parser,
     ) {}
 
-    /**
-     * @param array<string, mixed> $config
-     *
-     * @see https://docs.guzzlephp.org/en/stable/quickstart.html#creating-a-client
-     */
-    public function get(array $config = []): ClientInterface
+    public function parser(): Xml\Parser
     {
-        $mergedConfig = $this->defaults;
-
-        if ([] !== $config) {
-            Helper\ArrayHelper::mergeRecursive($mergedConfig, $config);
-        }
-
-        $client = new Client($mergedConfig);
-
-        $this->eventDispatcher->dispatch(new Event\ClientConstructed($client));
-
-        return $client;
+        return $this->parser;
     }
 }

--- a/src/Xml/ParserFactory.php
+++ b/src/Xml/ParserFactory.php
@@ -24,7 +24,9 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Xml;
 
 use EliasHaeussler\CacheWarmup\DependencyInjection;
+use EliasHaeussler\CacheWarmup\Event;
 use EliasHaeussler\CacheWarmup\Exception;
+use Psr\EventDispatcher;
 
 use function class_exists;
 use function is_subclass_of;
@@ -59,6 +61,9 @@ final readonly class ParserFactory
         if ($parser instanceof ConfigurableParser) {
             $parser->setOptions($options);
         }
+
+        $eventDispatcher = $container->get(EventDispatcher\EventDispatcherInterface::class);
+        $eventDispatcher->dispatch(new Event\ParserConstructed($parser));
 
         return $parser;
     }

--- a/tests/unit/Crawler/CrawlerFactoryTest.php
+++ b/tests/unit/Crawler/CrawlerFactoryTest.php
@@ -51,9 +51,12 @@ final class CrawlerFactoryTest extends Framework\TestCase
         $this->output = new Console\Output\BufferedOutput();
         $this->logger = new TransientLogger\TransientLogger();
         $this->eventDispatcher = new Tests\Fixtures\Classes\DummyEventDispatcher();
-        $this->clientFactory = new Src\Http\Client\ClientFactory([
-            RequestOptions::AUTH => ['username', 'password'],
-        ]);
+        $this->clientFactory = new Src\Http\Client\ClientFactory(
+            $this->eventDispatcher,
+            [
+                RequestOptions::AUTH => ['username', 'password'],
+            ],
+        );
         $this->subject = new Src\Crawler\CrawlerFactory(
             new Src\DependencyInjection\ContainerFactory(
                 $this->output,
@@ -138,6 +141,16 @@ final class CrawlerFactoryTest extends Framework\TestCase
         self::assertTrue(Tests\Fixtures\Classes\DummyStoppableCrawler::$stopOnFailure);
 
         Tests\Fixtures\Classes\DummyStoppableCrawler::$stopOnFailure = false;
+    }
+
+    #[Framework\Attributes\Test]
+    public function getDispatchesCrawlerConstructedEvent(): void
+    {
+        $this->subject->get(Tests\Fixtures\Classes\DummyCrawler::class);
+
+        self::assertTrue(
+            $this->eventDispatcher->wasDispatched(Src\Event\CrawlerConstructed::class),
+        );
     }
 
     #[Framework\Attributes\Test]

--- a/tests/unit/DependencyInjection/ContainerFactoryTest.php
+++ b/tests/unit/DependencyInjection/ContainerFactoryTest.php
@@ -52,7 +52,7 @@ final class ContainerFactoryTest extends Framework\TestCase
         $this->output = new Console\Output\NullOutput();
         $this->logger = new Log\NullLogger();
         $this->eventDispatcher = new EventDispatcher\EventDispatcher();
-        $this->clientFactory = new Src\Http\Client\ClientFactory();
+        $this->clientFactory = new Src\Http\Client\ClientFactory($this->eventDispatcher);
         $this->subject = new Src\DependencyInjection\ContainerFactory(
             $this->output,
             $this->logger,

--- a/tests/unit/Http/Client/ClientFactoryTest.php
+++ b/tests/unit/Http/Client/ClientFactoryTest.php
@@ -24,6 +24,7 @@ declare(strict_types=1);
 namespace EliasHaeussler\CacheWarmup\Tests\Http\Client;
 
 use EliasHaeussler\CacheWarmup as Src;
+use EliasHaeussler\CacheWarmup\Tests;
 use GuzzleHttp\Client;
 use PHPUnit\Framework;
 
@@ -36,13 +37,13 @@ use PHPUnit\Framework;
 #[Framework\Attributes\CoversClass(Src\Http\Client\ClientFactory::class)]
 final class ClientFactoryTest extends Framework\TestCase
 {
+    private Tests\Fixtures\Classes\DummyEventDispatcher $eventDispatcher;
     private Src\Http\Client\ClientFactory $subject;
 
     public function setUp(): void
     {
-        $this->subject = new Src\Http\Client\ClientFactory([
-            'foo' => 'baz',
-        ]);
+        $this->eventDispatcher = new Tests\Fixtures\Classes\DummyEventDispatcher();
+        $this->subject = new Src\Http\Client\ClientFactory($this->eventDispatcher, ['foo' => 'baz']);
     }
 
     #[Framework\Attributes\Test]
@@ -64,5 +65,15 @@ final class ClientFactoryTest extends Framework\TestCase
         ]);
 
         self::assertEquals($expected, $this->subject->get(['another' => 'foo']));
+    }
+
+    #[Framework\Attributes\Test]
+    public function getDispatchesClientConstructedEvent(): void
+    {
+        $this->subject->get();
+
+        self::assertTrue(
+            $this->eventDispatcher->wasDispatched(Src\Event\ClientConstructed::class),
+        );
     }
 }


### PR DESCRIPTION
This PR adds three new events:

* `ClientConstructed`
* `CrawlerConstructed`
* `ParserConstructed`

They are triggered if the respective services are built using their appropriate factories.