### PR TITLE
[BUGFIX] Mark cuyz/valinor 1.14.3 as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
 		"symfony/string": "^5.4.35 || ^6.4.3 || ^7.0.3"
 	},
 	"conflict": {
-		"cuyz/valinor": "1.14.0"
+		"cuyz/valinor": "1.14.0 || 1.14.3"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5c4f056b342f8449f40fc805866cd6b3",
+    "content-hash": "8e26ecde9604ca01aad234d51871d6f0",
     "packages": [
         {
             "name": "cuyz/valinor",


### PR DESCRIPTION
There's a bug in latest version of valinor that the console command malfunctioning. Thus, let's mark it as conflicting and wait for a bugfix release.

Related: CuyZ/Valinor#611
Related: eliashaeussler/typo3-warming#809