### PR TITLE
[BUGFIX] Mark cuyz/valinor v1.14.4 as conflicting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 		"phpunit/phpunit": "^10.1 || ^11.0"
 	},
 	"conflict": {
-		"cuyz/valinor": "1.14.0 || 1.14.3"
+		"cuyz/valinor": "1.14.0 || 1.14.3 || 1.14.4"
 	},
 	"autoload": {
 		"psr-4": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2da726f5f63b106ca0839ea41d60172e",
+    "content-hash": "12777b59a42b0926867583bbe49f16aa",
     "packages": [
         {
             "name": "cuyz/valinor",


### PR DESCRIPTION
Backport of #468.