### PR TITLE
[FEATURE] Make available crawling strategies in factory configurable

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -66,7 +66,6 @@ final class CacheWarmupCommand extends Console\Command\Command
     private const SUCCESSFUL = 0;
     private const FAILED = 1;
 
-    private readonly Crawler\Strategy\CrawlingStrategyFactory $crawlingStrategyFactory;
     private readonly Config\Component\OptionsParser $optionsParser;
     private readonly Time\TimeTracker $timeTracker;
     private Config\CacheWarmupConfig $config;
@@ -78,8 +77,8 @@ final class CacheWarmupCommand extends Console\Command\Command
 
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher = new EventDispatcher\EventDispatcher(),
+        private readonly Crawler\Strategy\CrawlingStrategyFactory $crawlingStrategyFactory = new Crawler\Strategy\CrawlingStrategyFactory(),
     ) {
-        $this->crawlingStrategyFactory = new Crawler\Strategy\CrawlingStrategyFactory();
         $this->optionsParser = new Config\Component\OptionsParser();
         $this->timeTracker = new Time\TimeTracker();
 

--- a/src/Crawler/Strategy/CrawlingStrategyFactory.php
+++ b/src/Crawler/Strategy/CrawlingStrategyFactory.php
@@ -34,21 +34,25 @@ use function in_array;
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
-final class CrawlingStrategyFactory
+final readonly class CrawlingStrategyFactory
 {
-    private const STRATEGIES = [
-        SortByChangeFrequencyStrategy::class,
-        SortByLastModificationDateStrategy::class,
-        SortByPriorityStrategy::class,
-    ];
+    /**
+     * @param list<class-string<CrawlingStrategy>> $strategies
+     */
+    public function __construct(
+        private array $strategies = [
+            SortByChangeFrequencyStrategy::class,
+            SortByLastModificationDateStrategy::class,
+            SortByPriorityStrategy::class,
+        ],
+    ) {}
 
     /**
      * @throws Exception\CrawlingStrategyDoesNotExist
      */
     public function get(string $name): CrawlingStrategy
     {
-        /** @var class-string<CrawlingStrategy> $strategy */
-        foreach (self::STRATEGIES as $strategy) {
+        foreach ($this->strategies as $strategy) {
             if ($name === $strategy::getName()) {
                 return new $strategy();
             }
@@ -58,14 +62,13 @@ final class CrawlingStrategyFactory
     }
 
     /**
-     * @return list<string>
+     * @return list<non-empty-string>
      */
     public function getAll(): array
     {
         return array_map(
-            /** @param class-string<CrawlingStrategy> $strategy */
             static fn (string $strategy) => $strategy::getName(),
-            self::STRATEGIES,
+            $this->strategies,
         );
     }
 


### PR DESCRIPTION
This pull request refactors the `CrawlingStrategyFactory` class to improve flexibility and updates the `CacheWarmupCommand` class to align with these changes. The most notable updates include making `CrawlingStrategyFactory` a readonly class with a constructor-injected strategies list and simplifying property initialization in `CacheWarmupCommand`.

### Refactoring of `CrawlingStrategyFactory`:

* Changed `CrawlingStrategyFactory` to a `readonly` class, ensuring immutability.
* Replaced the static `STRATEGIES` property with a constructor-injected `strategies` array, allowing for greater flexibility in defining available strategies.
* Updated the `getAll` method to use the instance-level `strategies` property instead of the removed static constant.

### Updates to `CacheWarmupCommand`:

* Removed the explicit property declaration for `CrawlingStrategyFactory` and replaced it with a constructor-injected readonly property, simplifying initialization. [[1]](diffhunk://#diff-b08aa98f54edce9be2444e8cc817aac1e77d79d2500a209ea6a12d4daa80da59L69) [[2]](diffhunk://#diff-b08aa98f54edce9be2444e8cc817aac1e77d79d2500a209ea6a12d4daa80da59R80-L82)