### PR TITLE
[TASK] Execute endless-mode runs in a loop

### DIFF
--- a/src/Command/CacheWarmupCommand.php
+++ b/src/Command/CacheWarmupCommand.php
@@ -58,7 +58,7 @@ use function strtolower;
 /**
  * CacheWarmupCommand.
  *
- * @author Elias Häußler <elias@heussler.dev>
+ * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
  */
 final class CacheWarmupCommand extends Console\Command\Command
@@ -73,7 +73,6 @@ final class CacheWarmupCommand extends Console\Command\Command
     private Formatter\Formatter $formatter;
     private Crawler\CrawlerFactory $crawlerFactory;
     private Xml\ParserFactory $parserFactory;
-    private bool $firstRun = true;
 
     public function __construct(
         private readonly EventDispatcherInterface $eventDispatcher = new EventDispatcher\EventDispatcher(),
@@ -486,15 +485,39 @@ HELP);
             throw new Console\Exception\RuntimeException('Neither sitemaps nor URLs are defined.', 1604261236);
         }
 
+        // Warn once before entering the endless run
+        if ($repeatAfter > 0) {
+            $this->showEndlessModeWarning($repeatAfter);
+        }
+
+        do {
+            $exitCode = $this->doExecute();
+
+            // Stop immediately if a run failed (also ends endless mode)
+            if (self::SUCCESSFUL !== $exitCode) {
+                return $exitCode;
+            }
+
+            // Wait before the next run in endless mode
+            if ($repeatAfter > 0) {
+                sleep($repeatAfter);
+            }
+        } while ($repeatAfter > 0);
+
+        return self::SUCCESSFUL;
+    }
+
+    /**
+     * @throws Exception\CrawlerDoesNotExist
+     * @throws Exception\CrawlerIsInvalid
+     * @throws Exception\OptionsAreInvalid
+     * @throws Exception\OptionsAreMalformed
+     */
+    private function doExecute(): int
+    {
         // Show header
         if ($this->formatter->isVerbose()) {
             $this->printHeader();
-        }
-
-        // Show warning on endless runs
-        if ($this->firstRun && $repeatAfter > 0) {
-            $this->showEndlessModeWarning($repeatAfter);
-            $this->firstRun = false;
         }
 
         // Print client options
@@ -528,18 +551,11 @@ HELP);
         // Print formatted cache warmup result
         $this->formatter->formatCacheWarmupResult($result, $this->timeTracker->getLastDuration());
 
-        // Early return if parsing or crawling failed
+        // Report failure if parsing or crawling failed
         if (!$this->config->areFailuresAllowed()
             && ([] !== $cacheWarmer->getFailedSitemaps() || !$result->isSuccessful())
         ) {
             return self::FAILED;
-        }
-
-        // Repeat on endless mode
-        if ($repeatAfter > 0) {
-            sleep($repeatAfter);
-
-            return $this->execute($input, $output);
         }
 
         return self::SUCCESSFUL;


### PR DESCRIPTION
Endless mode (`--repeat-after`) currently ends each run with return `$this->execute(...)`, so the command just calls itself again. Every recursive call stacks a new frame on top of the last, and PHP's garbage collector can't free the previous run's objects (`$cacheWarmer`, `$result`, the parsed URLs) while those frames are still on the stack. Run it long enough and memory just climbs — worse the bigger your sitemaps are, since each iteration pins a full set of URL objects.

Swapped the recursion for a plain do/while loop. Per-run logic lives in `doExecute()`now. `execute()` shows the "runs forever" warning once and drives the repetition. Each iteration's objects now go out of scope as soon as it ends, letting the garbage collector reclaim them immediately, so memory stays flat no matter how long it runs. Behaviour is otherwise unchanged: header prints each run, a failed run stops the loop, sleep interval is the same.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * The endless warmup mode warning now appears immediately before repeated runs begin.
  * Repeated runs stop right away when a run fails, instead of continuing.
  * Configured delays between runs are now respected, with the process waiting correctly before the next run starts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->