### PR TITLE
[BUGFIX] Restore dev dependencies after e2e PHAR build

### DIFF
--- a/tests/e2e/tearDown.sh
+++ b/tests/e2e/tearDown.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2155
+set -e
+
+readonly scriptPath="$(cd -- "$(dirname "$0")" >/dev/null 2>&1; pwd -P)"
+readonly rootPath="${scriptPath}/../.."
+
+# Restore dev dependencies so the working tree is never left in a --no-dev
+# state (which strips phpunit, phpstan, php-cs-fixer, rector, ...).
+echo >&2 "⏳ Restoring Composer dev dependencies..."
+composer install --quiet --working-dir "${rootPath}"
+echo >&2 -e "\033[1A\033[K✅ Restored Composer dev dependencies."


### PR DESCRIPTION
The e2e `setUp.sh` ran `composer install --no-dev` into the project root, stripping phpunit and the other require-dev tools out of the shared dev vendor/. Because `composer test` runs `@test:e2e` before `@test:unit`, the unit phase then failed locally with `phpunit: command not found` (exit 127), and any subsequent dev-tool invocation broke until a manual reinstall.

~~Register an EXIT trap in `_build_phar()` that re-installs the full dependency set after the PHAR is compiled, so the working tree is always returned to its dev state regardless of run order or build failure.~~

**Edit after review**: Moved the restore into a new top-level tests/e2e/tearDown.sh (auto-run by run.sh’s _tearDown, same as the docker suite) and reverted the setUp.sh trap.

The GitHub CI is unchanged because you've split the tests there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a cleanup step for end-to-end testing that restores development dependencies after test runs.
  * The process now provides clear progress and success messages, and stops immediately if an error occurs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->