### PR TITLE
[BUGFIX] Release settled requests during concurrent crawling

### DIFF
--- a/src/Http/Message/RequestPoolFactory.php
+++ b/src/Http/Message/RequestPoolFactory.php
@@ -93,15 +93,24 @@ final class RequestPoolFactory
 
     private function onFulfilled(Message\ResponseInterface $response, int $index): void
     {
+        $uri = $this->visited[$index]->getUri();
+
+        // Release the settled request to keep memory bound to the configured concurrency.
+        unset($this->visited[$index]);
+
         foreach ($this->handlers as $handler) {
-            $handler->onSuccess($response, $this->visited[$index]->getUri());
+            $handler->onSuccess($response, $uri);
         }
     }
 
     private function onRejected(Throwable $throwable, int $index, Promise\Promise $aggregate): void
     {
+        $uri = $this->visited[$index]->getUri();
+
+        unset($this->visited[$index]);
+
         foreach ($this->handlers as $handler) {
-            $handler->onFailure($throwable, $this->visited[$index]->getUri());
+            $handler->onFailure($throwable, $uri);
         }
 
         if ($this->stopOnFailure) {

--- a/tests/unit/Http/Message/RequestPoolFactoryTest.php
+++ b/tests/unit/Http/Message/RequestPoolFactoryTest.php
@@ -88,6 +88,20 @@ final class RequestPoolFactoryTest extends Framework\TestCase
     }
 
     #[Framework\Attributes\Test]
+    public function createPoolReleasesRequestsOnceTheirResponsesAreHandled(): void
+    {
+        $this->mockHandler->append(
+            new Psr7\Response(),
+            new Exception(),
+            new Psr7\Response(),
+        );
+
+        $this->subject->createPool()->promise()->wait();
+
+        self::assertPropertyEquals($this->subject, 'visited', []);
+    }
+
+    #[Framework\Attributes\Test]
     public function withClientClonesObjectAndAppliesGivenClient(): void
     {
         $this->mockHandler->append(new Psr7\Response());


### PR DESCRIPTION
This PR partly addresses #474 where a single run over ~300 sitemaps × ~5k URLs (~1.5M URLs) resulted in memory exhaustion:

`RequestPoolFactory` stashes each request in its `visited` array to map a settled response back to its URI, but never removed the entries. The array grew to the full URL count and kept every request alive for the whole crawl, regardless of concurrency — so memory climbed on large runs and could exhaust the limit.

Now each entry is unset in `onFulfilled()`/`onRejected()` once its URI has been read, keeping request retention bound to the concurrency window.

Each URL has three things held for the whole crawl:

1. **The request set** (`RequestPoolFactory::$visited`) — Kept grewing regardless of concurrency. Should :tm: be fixed with this PR.
2. **The parsed URL set** — `CacheWarmer` holds every `Sitemap\Url` for the run. This is the input set, inherent to the current design. (Not addressed here.)
3. **The collected results** — `CacheWarmupResult` keeps a `CrawlingResult` per URL, and that result carries the response/exception in its `data`. The existing `ResultCollectorHandlerTest` asserts this retention as contracted behaviour, so it is probably intended by you and therefore not stripped here.

This PR only addresses the first and removes only one of three retentions. Hence, a multi-million-URL run can still hit the limit from (2) and (3).