### PR TITLE
[BUGFIX] Assure tear down in E2E tests is always executed

### DIFF
--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -103,12 +103,24 @@ function _run_test_case() {
 }
 
 function _tearDown() {
+    local result="$1"
+
     if [ -f "${scriptPath}/tearDown.sh" ]; then
         "${scriptPath}/tearDown.sh"
+    fi
+
+    if [ "${result}" -eq 0 ]; then
+        echo 'Result: ✅ OK'
+        exit 0
+    else
+        echo 'Result: 🚨 Failed'
+        exit 1
     fi
 }
 
 _setUp
+
+trap '_tearDown "$result"' EXIT
 
 result=0
 
@@ -117,13 +129,3 @@ for suite in "${suites[@]}"; do
         result=1
     fi
 done
-
-_tearDown
-
-if [ "${result}" -eq 0 ]; then
-    echo 'Result: ✅ OK'
-    exit 0
-else
-    echo 'Result: 🚨 Failed'
-    exit 1
-fi

--- a/tests/e2e/tearDown.sh
+++ b/tests/e2e/tearDown.sh
@@ -10,3 +10,6 @@ readonly rootPath="${scriptPath}/../.."
 echo >&2 "⏳ Restoring Composer dev dependencies..."
 composer install --quiet --working-dir "${rootPath}"
 echo >&2 -e "\033[1A\033[K✅ Restored Composer dev dependencies."
+
+# Print empty newline
+echo


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test execution to handle cleanup and final pass/fail reporting more reliably.
  * Added a small output formatting update during teardown for clearer console logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->