### PR TITLE
[TASK] Display memory usage in console command

### DIFF
--- a/build/checks/phpstan-baseline.neon
+++ b/build/checks/phpstan-baseline.neon
@@ -19,7 +19,7 @@ parameters:
 			path: ../../src/Crawler/AbstractConfigurableCrawler.php
 
 		-
-			rawMessage: 'Property EliasHaeussler\CacheWarmup\Formatter\JsonFormatter::$json (array{parserResult?: array{success?: array{sitemaps: list<string>, urls: list<string>}, failure?: array{sitemaps: list<string>}, excluded?: array{sitemaps: list<string>, urls: list<string>}}, cacheWarmupResult?: array{success?: list<string>, failure?: list<string>, cancelled?: bool}, messages?: array<''error''|''info''|''success''|''warning'', list<string>>, time?: array{parse?: string, crawl?: string}}) does not accept iterable<string, mixed>.'
+			rawMessage: 'Property EliasHaeussler\CacheWarmup\Formatter\JsonFormatter::$json (array{parserResult?: array{success?: array{sitemaps: list<string>, urls: list<string>}, failure?: array{sitemaps: list<string>}, excluded?: array{sitemaps: list<string>, urls: list<string>}}, cacheWarmupResult?: array{success?: list<string>, failure?: list<string>, cancelled?: bool}, messages?: array<''error''|''info''|''success''|''warning'', list<string>>, time?: array{parse?: string, crawl?: string}, memoryUsage?: int}) does not accept iterable<string, mixed>.'
 			identifier: assign.propertyType
 			count: 2
 			path: ../../src/Formatter/JsonFormatter.php

--- a/docs/config-reference/format.md
+++ b/docs/config-reference/format.md
@@ -51,6 +51,7 @@ The resulting JSON object includes the following properties:
 | `messages`          | Contains all logged messages, grouped by message severity (`error`, `info`, `success`, `warning`)                      |
 | `parserResult`      | Lists all parsed and excluded XML sitemaps and URLs, grouped by their parsing state (`excluded`, `failure`, `success`) |
 | `time`              | Lists all tracked times during cache warmup (`crawl`, `parse`)                                                         |
+| `memoryUsage`       | Displays the whole memory consumption in bytes                                                                         |
 
 The complete JSON structure can be found in the provided
 [JSON schema](../../res/cache-warmup-result.schema.json).
@@ -108,7 +109,8 @@ The complete JSON structure can be found in the provided
     "time": {
         "parse": "0.18s",
         "crawl": "0.212s"
-    }
+    },
+    "memoryUsage": 4194304
 }
 
 ```

--- a/res/cache-warmup-result.schema.json
+++ b/res/cache-warmup-result.schema.json
@@ -101,6 +101,11 @@
 				}
 			},
 			"additionalProperties": false
+		},
+		"memoryUsage": {
+			"type": "integer",
+			"title": "Memory usage",
+			"description": "Displays the whole memory consumption in bytes"
 		}
 	},
 	"additionalProperties": false,

--- a/src/Formatter/JsonFormatter.php
+++ b/src/Formatter/JsonFormatter.php
@@ -33,6 +33,7 @@ use function array_map;
 use function is_array;
 use function is_scalar;
 use function json_encode;
+use function memory_get_usage;
 
 /**
  * JsonFormatter.
@@ -64,6 +65,7 @@ use function json_encode;
  *         parse?: string,
  *         crawl?: string,
  *     },
+ *     memoryUsage?: int,
  * }
  */
 final class JsonFormatter implements Formatter
@@ -116,6 +118,9 @@ final class JsonFormatter implements Formatter
         if (null !== $duration) {
             $this->addToJson('time/crawl', $duration->format());
         }
+
+        // Add memory usage
+        $this->addToJson('memoryUsage', memory_get_usage(true));
     }
 
     public function logMessage(string $message, MessageSeverity $severity = MessageSeverity::Info): void
@@ -150,9 +155,9 @@ final class JsonFormatter implements Formatter
     }
 
     /**
-     * @param string|bool|list<bool|float|int|resource|string|Stringable|null> $value
+     * @param string|int|bool|list<bool|float|int|resource|string|Stringable|null> $value
      */
-    private function addToJson(string $path, string|bool|array $value): void
+    private function addToJson(string $path, string|int|bool|array $value): void
     {
         if (is_scalar($value) && '' !== $value) {
             Helper\ArrayHelper::setValueByPath($this->json, $path, $value);

--- a/src/Formatter/TextFormatter.php
+++ b/src/Formatter/TextFormatter.php
@@ -29,6 +29,7 @@ use EliasHaeussler\CacheWarmup\Time;
 use Symfony\Component\Console;
 
 use function call_user_func;
+use function memory_get_usage;
 use function method_exists;
 use function sprintf;
 
@@ -164,13 +165,14 @@ final readonly class TextFormatter implements Formatter
             $this->io->warning('Cache warmup was cancelled due to a crawling failure.');
         }
 
-        // Print duration
+        // Print duration and memory usage
         if (null !== $duration) {
             $this->io->writeln(
                 sprintf(
-                    'Crawling %s %s',
+                    'Crawling %s %s, consumed %s of memory.',
                     $result->wasCancelled() ? 'cancelled after' : 'finished in',
                     $duration->format(),
+                    Helper\StringHelper::formatBytes(memory_get_usage(true)),
                 ),
             );
             $this->io->newLine();

--- a/src/Helper/StringHelper.php
+++ b/src/Helper/StringHelper.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Helper;
+
+use function abs;
+use function end;
+use function round;
+
+/**
+ * StringHelper.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+final readonly class StringHelper
+{
+    public static function formatBytes(int $bytes): string
+    {
+        $bytes = round($bytes);
+        $units = ['B', 'KB', 'MB', 'GB', 'TB', 'PB'];
+
+        foreach ($units as $unit) {
+            if (abs($bytes) < 1024 || $unit === end($units)) {
+                break;
+            }
+
+            $bytes /= 1024;
+        }
+
+        return round($bytes, 2).' '.($unit ?? 'B');
+    }
+}

--- a/tests/unit/Formatter/JsonFormatterTest.php
+++ b/tests/unit/Formatter/JsonFormatterTest.php
@@ -34,6 +34,8 @@ use Symfony\Component\Console;
  *
  * @author Elias Häußler <elias@haeussler.dev>
  * @license GPL-3.0-or-later
+ *
+ * @phpstan-import-type JsonArray from Src\Formatter\JsonFormatter
  */
 #[Framework\Attributes\CoversClass(Src\Formatter\JsonFormatter::class)]
 final class JsonFormatterTest extends Framework\TestCase
@@ -164,7 +166,7 @@ final class JsonFormatterTest extends Framework\TestCase
 
         $this->subject->formatCacheWarmupResult($result);
 
-        self::assertSame([], $this->subject->getJson());
+        self::assertSame([], $this->getValidatedJson());
     }
 
     #[Framework\Attributes\Test]
@@ -182,7 +184,7 @@ final class JsonFormatterTest extends Framework\TestCase
                     'success' => [$url],
                 ],
             ],
-            $this->subject->getJson(),
+            $this->getValidatedJson(),
         );
     }
 
@@ -201,7 +203,7 @@ final class JsonFormatterTest extends Framework\TestCase
                     'failure' => [$url],
                 ],
             ],
-            $this->subject->getJson(),
+            $this->getValidatedJson(),
         );
     }
 
@@ -219,7 +221,7 @@ final class JsonFormatterTest extends Framework\TestCase
                     'cancelled' => true,
                 ],
             ],
-            $this->subject->getJson(),
+            $this->getValidatedJson(),
         );
     }
 
@@ -237,7 +239,7 @@ final class JsonFormatterTest extends Framework\TestCase
                     'crawl' => $duration->format(),
                 ],
             ],
-            $this->subject->getJson(),
+            $this->getValidatedJson(),
         );
     }
 
@@ -270,5 +272,20 @@ final class JsonFormatterTest extends Framework\TestCase
         yield 'info' => [Src\Formatter\MessageSeverity::Info, $message(Src\Formatter\MessageSeverity::Info)];
         yield 'success' => [Src\Formatter\MessageSeverity::Success, $message(Src\Formatter\MessageSeverity::Success)];
         yield 'warning' => [Src\Formatter\MessageSeverity::Warning, $message(Src\Formatter\MessageSeverity::Warning)];
+    }
+
+    /**
+     * @return JsonArray
+     */
+    private function getValidatedJson(): array
+    {
+        $json = $this->subject->getJson();
+
+        self::assertArrayHasKey('memoryUsage', $json);
+        self::assertGreaterThan(0, $json['memoryUsage']);
+
+        unset($json['memoryUsage']);
+
+        return $json;
     }
 }

--- a/tests/unit/Formatter/TextFormatterTest.php
+++ b/tests/unit/Formatter/TextFormatterTest.php
@@ -302,7 +302,7 @@ final class TextFormatterTest extends Framework\TestCase
         $output = $this->output->fetch();
 
         self::assertNotEmpty($output);
-        self::assertStringContainsString('Crawling finished in 0.5s', $output);
+        self::assertMatchesRegularExpression('/Crawling finished in 0\\.5s, consumed \\d+ [KMGTP]B of memory\\./', $output);
     }
 
     /**

--- a/tests/unit/Helper/StringHelperTest.php
+++ b/tests/unit/Helper/StringHelperTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Composer package "eliashaeussler/cache-warmup".
+ *
+ * Copyright (C) 2020-2026 Elias Häußler <elias@haeussler.dev>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+namespace EliasHaeussler\CacheWarmup\Tests\Helper;
+
+use EliasHaeussler\CacheWarmup as Src;
+use Generator;
+use PHPUnit\Framework;
+
+/**
+ * StringHelperTest.
+ *
+ * @author Elias Häußler <elias@haeussler.dev>
+ * @license GPL-3.0-or-later
+ */
+#[Framework\Attributes\CoversClass(Src\Helper\StringHelper::class)]
+final class StringHelperTest extends Framework\TestCase
+{
+    /**
+     * @return Generator<string, array{int, string}>
+     */
+    public static function formatBytesReturnsFormattedBytesDataProvider(): Generator
+    {
+        yield 'bytes' => [1023, '1023 B'];
+        yield 'kilobytes' => [1024, '1 KB'];
+        yield 'megabytes' => [1024 * 1024, '1 MB'];
+        yield 'gigabytes' => [1024 * 1024 * 1024, '1 GB'];
+        yield 'terabytes' => [1024 * 1024 * 1024 * 1024, '1 TB'];
+        yield 'petabytes' => [1024 * 1024 * 1024 * 1024 * 1024, '1 PB'];
+    }
+
+    #[Framework\Attributes\Test]
+    #[Framework\Attributes\DataProvider('formatBytesReturnsFormattedBytesDataProvider')]
+    public function formatBytesReturnsFormattedBytes(int $bytes, string $expected): void
+    {
+        self::assertSame($expected, Src\Helper\StringHelper::formatBytes($bytes));
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cache warmup output now includes memory usage alongside elapsed time.
  * JSON output now includes a `memoryUsage` field, and the schema/docs reflect the updated format.
* **Bug Fixes**
  * Improved compatibility of the JSON output format with the updated memory usage data.
* **Documentation**
  * Updated the formatter reference with the new memory usage example and field description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->